### PR TITLE
Fix rom creation by adding stream to streamsByProtoAddr the first time a unique is found.

### DIFF
--- a/DCSDecoder/DCSDecoder.cpp
+++ b/DCSDecoder/DCSDecoder.cpp
@@ -158,6 +158,14 @@ dcsGameInfo[] ={
 	{ DCSDecoder::GameID::ToM, "Theatre of Magic", "Theatre of Magic" },
 	{ DCSDecoder::GameID::WCS, "World Cup Soccer", "World Cup Soccer" },
 	{ DCSDecoder::GameID::WDI, "Who Dunnit", "WDI Pinball" },
+	// Added some video game roms
+	{ DCSDecoder::GameID::NBAHT, "NBA Hangtime", "NBA HANGTIME GAME SOUND ROMS" },
+	{ DCSDecoder::GameID::NBAHT, "NBA Hangtime (Hack)", "NBA SUPER HANGTIME" },
+	{ DCSDecoder::GameID::KINST, "Killer Instinct", "Killer Instinct (c)" },
+	{ DCSDecoder::GameID::MK3, "Mortal Kombat 3", "Mortal Kombat III(c) 1994 Williams - DWF" },
+	{ DCSDecoder::GameID::MK2, "Mortal Kombat 2", "Mortal Kombat II (c) 1993 Williams - DWF" },
+	{ DCSDecoder::GameID::WWFW, "WWF Wrestelmania Arcade", "WWF Video (c) 1993 Williams Electronics Games, Inc." },
+	// comma on end.
 };
 
 // Infer the game ID from a siganture string

--- a/DCSDecoder/DCSDecoder.cpp
+++ b/DCSDecoder/DCSDecoder.cpp
@@ -130,6 +130,7 @@ static const struct
 	const char *regex;			// regex pattern to apply to a U2 ROM signature to identify the game
 }
 dcsGameInfo[] ={
+	// Pinball game roms
 	{ DCSDecoder::GameID::AFM, "Attack from Mars", "Attack from Mars" },
 	{ DCSDecoder::GameID::CC, "Cactus Canyon", "Cactus Canyon" },
 	{ DCSDecoder::GameID::CP, "The Champion Pub", "Champion Pub" },
@@ -158,12 +159,13 @@ dcsGameInfo[] ={
 	{ DCSDecoder::GameID::ToM, "Theatre of Magic", "Theatre of Magic" },
 	{ DCSDecoder::GameID::WCS, "World Cup Soccer", "World Cup Soccer" },
 	{ DCSDecoder::GameID::WDI, "Who Dunnit", "WDI Pinball" },
-	// Added some video game roms
+	// Video game roms
+	{ DCSDecoder::GameID::KINST, "Killer Instinct", "Killer Instinct (c)" },
+	{ DCSDecoder::GameID::MK2, "Mortal Kombat 2", "Mortal Kombat II (c) 1993 Williams - DWF" },
+	{ DCSDecoder::GameID::MK3, "Mortal Kombat 3", "Mortal Kombat III(c) 1994 Williams - DWF" },
 	{ DCSDecoder::GameID::NBAHT, "NBA Hangtime", "NBA HANGTIME GAME SOUND ROMS" },
 	{ DCSDecoder::GameID::NBAHT, "NBA Hangtime (Hack)", "NBA SUPER HANGTIME" },
-	{ DCSDecoder::GameID::KINST, "Killer Instinct", "Killer Instinct (c)" },
-	{ DCSDecoder::GameID::MK3, "Mortal Kombat 3", "Mortal Kombat III(c) 1994 Williams - DWF" },
-	{ DCSDecoder::GameID::MK2, "Mortal Kombat 2", "Mortal Kombat II (c) 1993 Williams - DWF" },
+	{ DCSDecoder::GameID::RMPGWT, "Rampage World Tour", "WMS Rampage II Video" },
 	{ DCSDecoder::GameID::WWFW, "WWF Wrestelmania Arcade", "WWF Video (c) 1993 Williams Electronics Games, Inc." },
 	// comma on end.
 };

--- a/DCSDecoder/DCSDecoder.h
+++ b/DCSDecoder/DCSDecoder.h
@@ -1026,14 +1026,16 @@ public:
 		// Who Dunnit, 1995 (no known hacks)
 		WDI,
 		// Video games
-		// NBA Hangtime, 1994
-		NBAHT,
 		// Killer Instinct, 1994
 		KINST,
-		// Mortal Kombat 3, 1994
-		MK3,
 		// Mortal Kombat 2, 1993
 		MK2,
+		// Mortal Kombat 3, 1994
+		MK3,
+		// NBA Hangtime, 1994
+		NBAHT,
+		// Rampage World Tour
+		RMPGWT,
 		// WWF Wrestlemania Arcade, 1993
 		WWFW
 		// end no comma

--- a/DCSDecoder/DCSDecoder.h
+++ b/DCSDecoder/DCSDecoder.h
@@ -1024,7 +1024,19 @@ public:
 		WCS,
 
 		// Who Dunnit, 1995 (no known hacks)
-		WDI
+		WDI,
+		// Video games
+		// NBA Hangtime, 1994
+		NBAHT,
+		// Killer Instinct, 1994
+		KINST,
+		// Mortal Kombat 3, 1994
+		MK3,
+		// Mortal Kombat 2, 1993
+		MK2,
+		// WWF Wrestlemania Arcade, 1993
+		WWFW
+		// end no comma
 	};
 
 	// infer the game ID from a ROM U2 signature string

--- a/DCSEncoder/DCSCompiler.cpp
+++ b/DCSEncoder/DCSCompiler.cpp
@@ -124,7 +124,7 @@ bool DCSCompiler::LoadPrototypeROM(const char *romZipName, bool patchMode, std::
 				auto &track = tracks.emplace(std::piecewise_construct, std::forward_as_tuple(i), std::forward_as_tuple()).first->second;
 
 				// mark is as not coming from the script, so that the script can replace it
-				track.fromRom = false;
+				track.fromRom = true;
 
 				// store the basic information
 				track.trackNo = i;

--- a/DCSEncoder/DCSCompiler.cpp
+++ b/DCSEncoder/DCSCompiler.cpp
@@ -177,6 +177,9 @@ bool DCSCompiler::LoadPrototypeROM(const char *romZipName, bool patchMode, std::
 								// yet.  Create a new stream object.
 								auto &stream = streams.emplace_back(streamAddr);
 
+								// Add the new stream to streamsByProtoAddr
+								streamsByProtoAddr[streamAddr] = &stream;
+
 								// store a direct pointer to the stream data in the prototype ROM
 								stream.refName = DCSEncoder::format("%s($07x)", romZipName, streamAddr);
 								stream.data = streamPtr.p;


### PR DESCRIPTION
- It seems streamsByProtoAddr was never populated after adding a stream.
- Track replacement was not working as fromRom was set to false by default.