### PR TITLE
Update DCSCompiler.cpp

### DIFF
--- a/DCSEncoder/DCSCompiler.cpp
+++ b/DCSEncoder/DCSCompiler.cpp
@@ -107,7 +107,8 @@ bool DCSCompiler::LoadPrototypeROM(const char *romZipName, bool patchMode, std::
 
 	// note the number of channels supported in the prototype firmware
 	numChannels = decoder.GetNumChannels();
-	maxChannelNumber = numChannels - 1;
+	
+	// maxChannelNumber = numChannels - 1;
 
 	// if we're in patch mode, load all of the tracks and streams from the old ROM
 	if (patchMode)


### PR DESCRIPTION
Noticed i couldn't use channel '5' in my script, even though i had  6-channel parent rom:

Fix: Don't deduct an extra channel.
{0,1,2,3,4,5} = 6 channels.