### PR TITLE
Fix crash when stream preamble crosses a 4KB ROM bank boundary

### DIFF
--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -198,7 +198,7 @@ static std::string disassembleProgram(
     };
 
     for (int guard = 0; guard < 4096 && p + 2 < bnkSize; ++guard) {
-        uint16_t waitCount = (uint16_t)((bnk[p] << 8) | bnk[p+1]);  p += 2;
+        uint16_t waitCount = read_le16(bnk + p);  p += 2;
         if (p >= bnkSize) break;
         uint8_t op = bnk[p++];
 
@@ -331,7 +331,7 @@ static std::vector<StreamRef> parseProgram(
 
     int loopDepth = 0;
     for (int guard = 0; guard < 4096 && p + 2 < bnkSize; ++guard) {
-        uint16_t cp  = (uint16_t)((bnk[p] << 8) | bnk[p+1]);  p += 2;
+        uint16_t cp  = read_le16(bnk + p);  p += 2;
         if (cp == 0xFFFF) break;
         if (p >= bnkSize) break;
         uint8_t op = bnk[p++];

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -509,19 +509,17 @@ int main(int argc, char *argv[])
     // --- print track programs if requested ---
     if (programMode) {
         for (auto &t : tracks) {
-            std::string name;
-            auto it = names.find(t.trackNum);
-            if (it != names.end()) name = it->second;
+            uint8_t channel = (t.poff + 1 < bnkSize) ? bnk.data()[t.poff + 1] : 0;
 
-            if (!name.empty())
-                printf("Track $%04X \"%s\"\n", t.trackNum, name.c_str());
-            else
-                printf("Track $%04X\n", t.trackNum);
+            // Header matches DCSExplorer -p format; use file offset in place of ROM address
+            printf("Track $%04x Channel %d {    // Address $%06zx\n",
+                t.trackNum, channel, t.poff);
 
             std::string prog = disassembleProgram(bnk.data(), bnkSize, t.poff, "    ");
             if (!prog.empty())
                 printf("%s\n", prog.c_str());
-            printf("\n");
+
+            printf("};\n");
         }
     }
 

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -140,10 +140,6 @@ static bool writeWav(const char *path, DCSDecoder *decoder, uint16_t nFrames)
         for (int si = 0; si < 240; ++si)
             buf[si] = decoder->GetNextSample();
         ok = (fwrite(buf, sizeof(buf), 1, fp) == 1);
-
-        // Cancel looping one frame before end so it tapers cleanly
-        if (frame + 2 >= nFrames)
-            decoder->SoftBoot();
     }
 
     ok = (fclose(fp) == 0) && ok;
@@ -155,10 +151,9 @@ static bool writeWav(const char *path, DCSDecoder *decoder, uint16_t nFrames)
 // ---------------------------------------------------------------------------
 
 struct Track {
-    int     trackNum;
+    int      trackNum;
     uint32_t streamAddr;   // file offset into BNK
-    size_t  streamBytes;   // length derived from next-addr method
-    uint16_t nFrames;      // from first 2 bytes of stream data (BE uint16)
+    size_t   streamBytes;  // length derived from next-addr method
 };
 
 // ---------------------------------------------------------------------------
@@ -246,13 +241,9 @@ int main(int argc, char *argv[])
         uint32_t streamAddr = read_be24(bnk.data() + playlistOff + BNK_STREAM_ADDR_OFF);
         if (streamAddr == 0 || streamAddr >= bnkSize) continue;
 
-        uint16_t nFrames = read_be16(bnk.data() + streamAddr);
-        if (nFrames == 0) continue;  // skip anomalous/null entries
-
         Track t;
-        t.trackNum   = i;
-        t.streamAddr = streamAddr;
-        t.nFrames    = nFrames;
+        t.trackNum    = i;
+        t.streamAddr  = streamAddr;
         t.streamBytes = 0;  // filled below
         tracks.push_back(t);
     }
@@ -310,12 +301,21 @@ int main(int argc, char *argv[])
         // Load stream into decoder
         const uint8_t *streamData = bnk.data() + t.streamAddr;
         DCSDecoder::ROMPointer streamPtr(0, streamData);
+
+        // Use GetStreamInfo for the authoritative frame count
+        auto info = decoder.GetStreamInfo(streamPtr);
+        if (info.nFrames <= 0) {
+            printf("  SKIP $%04X  (GetStreamInfo returned 0 frames)\n", t.trackNum);
+            ++nSkip;
+            continue;
+        }
+
         decoder.SoftBoot();
         decoder.LoadAudioStream(0, streamPtr, 0x64);
 
-        bool ok = writeWav(filename, &decoder, t.nFrames);
+        bool ok = writeWav(filename, &decoder, (uint16_t)info.nFrames);
         if (ok) {
-            printf("  OK   $%04X  %5u frames  %s\n", t.trackNum, t.nFrames, filename);
+            printf("  OK   $%04X  %5d frames  %s\n", t.trackNum, info.nFrames, filename);
             ++nOk;
         } else {
             printf("  ERR  $%04X  %s\n", t.trackNum, filename);

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -162,7 +162,7 @@ static std::vector<StreamRef> parseProgram(
                 uint32_t abs  = stored + (uint32_t)vs;
                 if (abs + 18 < bnkSize) {
                     uint16_t nf = read_be16(bnk + abs);
-                    if (nf > 0 && nf <= 2000)
+                    if (nf > 0)
                         result.push_back({ abs, curMix, loop });
                 }
             }

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -27,10 +27,11 @@ static const size_t BNK_COUNT_OFFSET      = 0x80;  // LE uint16 - number of inde
 static const size_t BNK_INDEX_OFFSET      = 0x86;  // LE uint32 per slot, relative to DATA_BASE
 static const size_t BNK_DATA_BASE         = 0x5FA; // start of playlist + stream data
 static const size_t BNK_PLAYLIST_STRIDE   = 18;    // bytes per playlist program entry
-static const size_t BNK_STREAM_ADDR_OFF   = 11;    // offset within playlist entry: 3-byte BE relative stream addr
-// The stored addr is relative to the addr field's own file position (var_start = playlistOff + BNK_STREAM_ADDR_OFF).
-// absolute_stream_addr = stored_BE24 + var_start
-// The stream at absolute_stream_addr is standard DCS format: [U16 BE nFrames][16-byte header][packed bits]
+// Stream addresses are found by scanning for the fix_stream_addr pattern:
+//   [2 lead bytes] 01 00 [3-byte BE relative addr] 01
+// absolute_stream_addr = stored_BE24 + var_start  (var_start = position after "01 00")
+// The stream at that address is standard DCS format: [U16 BE nFrames][16-byte header][packed bits]
+// The slot->stream mapping uses rel/18 as index into the ordered stream table.
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -229,27 +230,45 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    // Collect valid tracks
+    // Build stream table by scanning for the fix_stream_addr pattern:
+    // [2 lead bytes] 01 00 [3-byte BE relative addr] 01
+    // absolute_addr = stored_BE24 + var_start
+    struct StreamEntry { uint32_t absAddr; uint8_t mixLevel; };
+    std::vector<StreamEntry> streamTable;
+    {
+        const uint8_t *p = bnk.data();
+        for (size_t k = 2; k + 6 < bnkSize; ++k) {
+            if (p[k] != 0x01 || p[k+1] != 0x00) continue;
+            if (p[k+5] != 0x01) continue;
+            size_t varStart = k + 2;
+            uint32_t stored = read_be24(p + varStart);
+            if (stored == 0) continue;
+            uint32_t absAddr = stored + (uint32_t)varStart;
+            if (absAddr + 18 >= bnkSize) continue;
+            // Validate: first 2 bytes at absAddr should be a plausible frame count
+            uint16_t nf = read_be16(p + absAddr);
+            if (nf == 0 || nf > 2000) continue;
+            StreamEntry se;
+            se.absAddr  = absAddr;
+            se.mixLevel = p[k - 3];  // byte[6] of 18-byte entry = 3 bytes before "01 00"
+            streamTable.push_back(se);
+            k += 5;  // skip past this match
+        }
+    }
+
+    // Collect valid tracks: slot -> stream via rel/18 as index into streamTable
     std::vector<Track> tracks;
     for (int i = 0; i < (int)slotCount; ++i) {
         uint32_t rel = read_le32(bnk.data() + BNK_INDEX_OFFSET + i * 4);
         if (rel == 0xFFFFFFFF) continue;
-        if (i == 0 && rel == 0) continue;  // slot 0 unused sentinel
 
-        size_t playlistOff = BNK_DATA_BASE + rel;
-        if (playlistOff + BNK_PLAYLIST_STRIDE > bnkSize) continue;
-
-        // The stored address is relative to the address field's own file position.
-        size_t varStart = playlistOff + BNK_STREAM_ADDR_OFF;
-        uint32_t storedAddr = read_be24(bnk.data() + varStart);
-        if (storedAddr == 0) continue;
-        uint32_t streamAddr = storedAddr + (uint32_t)varStart;
-        if (streamAddr + 18 >= bnkSize) continue;
+        size_t streamIdx = rel / BNK_PLAYLIST_STRIDE;
+        if (streamIdx >= streamTable.size()) continue;
 
         Track t;
         t.trackNum   = i;
-        t.streamAddr = streamAddr;
-        t.mixLevel   = bnk[playlistOff + 6];  // byte[6] = channel mixing level
+        t.streamAddr = streamTable[streamIdx].absAddr;
+        t.mixLevel   = streamTable[streamIdx].mixLevel;
         tracks.push_back(t);
     }
 

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -187,6 +187,7 @@ static std::string disassembleProgram(
 
     std::string loopIndent;
     const char *perLoopIndent = "  ";
+    std::vector<uint8_t> loopCountStack;  // loop counts, to detect infinite-loop termination
 
     auto appendLine = [&](const std::string &instr, const std::string &hexDesc) {
         if (!out.empty()) out += "\n";
@@ -198,7 +199,7 @@ static std::string disassembleProgram(
     };
 
     for (int guard = 0; guard < 4096 && p + 2 < bnkSize; ++guard) {
-        uint16_t waitCount = read_le16(bnk + p);  p += 2;
+        uint16_t waitCount = (uint16_t)((bnk[p] << 8) | bnk[p+1]);  p += 2;
         if (p >= bnkSize) break;
         uint8_t op = bnk[p++];
 
@@ -289,6 +290,7 @@ static std::string disassembleProgram(
                 if (cnt != 0) snprintf(istr, sizeof(istr), "Loop (%d) {", cnt);
                 else          snprintf(istr, sizeof(istr), "Loop {");
                 instr = istr;
+                loopCountStack.push_back(cnt);
             }
             break;
 
@@ -296,6 +298,11 @@ static std::string disassembleProgram(
             // dedent before printing the closing brace
             if (!loopIndent.empty()) loopIndent = loopIndent.substr(2);
             instr = "}";
+            // a Loop(0) (infinite) end means execution can never continue past here
+            if (!loopCountStack.empty()) {
+                if (loopCountStack.back() == 0) done = true;
+                loopCountStack.pop_back();
+            }
             break;
 
         default:
@@ -331,7 +338,7 @@ static std::vector<StreamRef> parseProgram(
 
     int loopDepth = 0;
     for (int guard = 0; guard < 4096 && p + 2 < bnkSize; ++guard) {
-        uint16_t cp  = read_le16(bnk + p);  p += 2;
+        uint16_t cp  = (uint16_t)((bnk[p] << 8) | bnk[p+1]);  p += 2;
         if (cp == 0xFFFF) break;
         if (p >= bnkSize) break;
         uint8_t op = bnk[p++];

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -112,6 +112,50 @@ static std::map<int, std::string> parseLst(const char *lstPath)
 }
 
 // ---------------------------------------------------------------------------
+// WAV writer - writes nFrames + 2 tail frames from the decoder
+// ---------------------------------------------------------------------------
+
+static bool writeOneWav(const char *path, DCSDecoderNative &decoder,
+                        const uint8_t *bnkData, uint32_t absAddr,
+                        uint8_t mixLevel, int nFrames)
+{
+    FILE *fp = nullptr;
+    if (fopen_s(&fp, path, "wb") != 0 || fp == nullptr) {
+        printf("  ERROR: cannot open \"%s\" (errno %d)\n", path, errno);
+        return false;
+    }
+
+    uint32_t wavFrames = (uint32_t)nFrames + 2;
+    uint8_t hdr[44];
+    memset(hdr, 0, sizeof(hdr));
+    uint32_t dataBytes = wavFrames * 240 * 2;
+    memcpy(&hdr[0], "RIFF\0\0\0\0WAVEfmt ", 16);
+    *reinterpret_cast<uint32_t*>(&hdr[4])  = dataBytes + 44 - 8;
+    *reinterpret_cast<uint32_t*>(&hdr[16]) = 16;
+    *reinterpret_cast<uint16_t*>(&hdr[20]) = 1;
+    *reinterpret_cast<uint16_t*>(&hdr[22]) = 1;
+    *reinterpret_cast<uint32_t*>(&hdr[24]) = 31250;
+    *reinterpret_cast<uint32_t*>(&hdr[28]) = 31250 * 2;
+    *reinterpret_cast<uint16_t*>(&hdr[32]) = 2;
+    *reinterpret_cast<uint16_t*>(&hdr[34]) = 16;
+    memcpy(&hdr[36], "data", 4);
+    *reinterpret_cast<uint32_t*>(&hdr[40]) = dataBytes;
+    bool ok = (fwrite(hdr, 44, 1, fp) == 1);
+
+    DCSDecoder::ROMPointer streamPtr(0, bnkData + absAddr);
+    decoder.SoftBoot();
+    decoder.LoadAudioStream(0, streamPtr, mixLevel);
+    for (uint32_t f = 0; f < wavFrames && ok; ++f) {
+        int16_t buf[240];
+        for (int s = 0; s < 240; ++s) buf[s] = decoder.GetNextSample();
+        ok = (fwrite(buf, sizeof(buf), 1, fp) == 1);
+    }
+
+    ok = (fclose(fp) == 0) && ok;
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
 // Track entry - one or more streams played sequentially
 // ---------------------------------------------------------------------------
 
@@ -203,13 +247,16 @@ int main(int argc, char *argv[])
     printf("BnkExtract - DCS2 BNK audio extractor\n\n");
 
     // --- parse arguments ---
-    const char *bnkPath = nullptr;
-    const char *lstPath = nullptr;
-    std::string outDir  = ".";
+    const char *bnkPath  = nullptr;
+    const char *lstPath  = nullptr;
+    std::string outDir   = ".";
+    bool samplesMode     = false;
 
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "--outdir") == 0 && i + 1 < argc) {
             outDir = argv[++i];
+        } else if (strcmp(argv[i], "--samples") == 0) {
+            samplesMode = true;
         } else if (!bnkPath) {
             bnkPath = argv[i];
         } else if (!lstPath) {
@@ -218,7 +265,8 @@ int main(int argc, char *argv[])
     }
 
     if (!bnkPath) {
-        printf("Usage: BnkExtract <file.BNK> [file.LST] [--outdir <dir>]\n");
+        printf("Usage: BnkExtract <file.BNK> [file.LST] [--outdir <dir>] [--samples]\n");
+        printf("  --samples  Write each individual stream as a separate WAV\n");
         return 1;
     }
 
@@ -312,7 +360,6 @@ int main(int argc, char *argv[])
     // --- extract each track ---
     int nOk = 0, nError = 0, nSkip = 0;
     for (auto &t : tracks) {
-        // Build output filename
         std::string name;
         auto it = names.find(t.trackNum);
         if (it != names.end())
@@ -320,88 +367,114 @@ int main(int argc, char *argv[])
         if (name.empty())
             name = "track";
 
-        char filename[512];
-        snprintf(filename, sizeof(filename), "%s/%s_%04X.wav",
-            outDir.c_str(), name.c_str(), t.trackNum);
+        if (samplesMode) {
+            // Write each stream in the track as a separate WAV
+            for (size_t si = 0; si < t.streams.size(); ++si) {
+                auto &sr = t.streams[si];
+                DCSDecoder::ROMPointer streamPtr(0, bnk.data() + sr.absAddr);
+                auto info = decoder.GetStreamInfo(streamPtr);
+                if (info.nFrames <= 0) {
+                    printf("  SKIP $%04X/%zu  (0 frames)\n", t.trackNum, si + 1);
+                    ++nSkip;
+                    continue;
+                }
 
-        // Get frame counts for all streams in this track
-        std::vector<int> frameCounts;
-        int totalFrames = 0;
-        bool valid = true;
-        for (auto &sr : t.streams) {
-            DCSDecoder::ROMPointer streamPtr(0, bnk.data() + sr.absAddr);
-            auto info = decoder.GetStreamInfo(streamPtr);
-            if (info.nFrames <= 0) { valid = false; break; }
-            int n = info.nFrames * (sr.loopCount > 1 ? sr.loopCount : 1);
-            frameCounts.push_back(n);
-            totalFrames += n;
-        }
-        if (!valid || totalFrames <= 0) {
-            printf("  SKIP $%04X  (no valid frames)\n", t.trackNum);
-            ++nSkip;
-            continue;
-        }
+                char filename[512];
+                snprintf(filename, sizeof(filename), "%s/%s_%04X_%zu.wav",
+                    outDir.c_str(), name.c_str(), t.trackNum, si + 1);
 
-        // Write WAV: streams decoded back-to-back
-        FILE *fp = nullptr;
-        if (fopen_s(&fp, filename, "wb") != 0 || fp == nullptr) {
-            printf("  ERR  $%04X  cannot open %s\n", t.trackNum, filename);
-            ++nError;
-            continue;
-        }
+                bool ok = writeOneWav(filename, decoder, bnk.data(),
+                                      sr.absAddr, sr.mixLevel, info.nFrames);
+                if (ok) {
+                    printf("  OK   $%04X/%zu  %5d frames  %s\n",
+                        t.trackNum, si + 1, info.nFrames, filename);
+                    ++nOk;
+                } else {
+                    printf("  ERR  $%04X/%zu  %s\n", t.trackNum, si + 1, filename);
+                    ++nError;
+                }
+            }
+        } else {
+            // Write all streams concatenated into one WAV
+            char filename[512];
+            snprintf(filename, sizeof(filename), "%s/%s_%04X.wav",
+                outDir.c_str(), name.c_str(), t.trackNum);
 
-        // Write WAV header with total frame count + 2 tail frames
-        uint32_t wavFrames = (uint32_t)totalFrames + 2;
-        uint8_t hdr[44];
-        memset(hdr, 0, sizeof(hdr));
-        uint32_t dataBytes = wavFrames * 240 * 2;
-        memcpy(&hdr[0], "RIFF\0\0\0\0WAVEfmt ", 16);
-        *reinterpret_cast<uint32_t*>(&hdr[4])  = dataBytes + 44 - 8;
-        *reinterpret_cast<uint32_t*>(&hdr[16]) = 16;
-        *reinterpret_cast<uint16_t*>(&hdr[20]) = 1;
-        *reinterpret_cast<uint16_t*>(&hdr[22]) = 1;
-        *reinterpret_cast<uint32_t*>(&hdr[24]) = 31250;
-        *reinterpret_cast<uint32_t*>(&hdr[28]) = 31250 * 2;
-        *reinterpret_cast<uint16_t*>(&hdr[32]) = 2;
-        *reinterpret_cast<uint16_t*>(&hdr[34]) = 16;
-        memcpy(&hdr[36], "data", 4);
-        *reinterpret_cast<uint32_t*>(&hdr[40]) = dataBytes;
-        bool ok = (fwrite(hdr, 44, 1, fp) == 1);
+            std::vector<int> frameCounts;
+            int totalFrames = 0;
+            bool valid = true;
+            for (auto &sr : t.streams) {
+                DCSDecoder::ROMPointer streamPtr(0, bnk.data() + sr.absAddr);
+                auto info = decoder.GetStreamInfo(streamPtr);
+                if (info.nFrames <= 0) { valid = false; break; }
+                int n = info.nFrames * (sr.loopCount > 1 ? sr.loopCount : 1);
+                frameCounts.push_back(n);
+                totalFrames += n;
+            }
+            if (!valid || totalFrames <= 0) {
+                printf("  SKIP $%04X  (no valid frames)\n", t.trackNum);
+                ++nSkip;
+                continue;
+            }
 
-        // Decode each stream in sequence
-        for (size_t si = 0; si < t.streams.size() && ok; ++si) {
-            auto &sr = t.streams[si];
-            DCSDecoder::ROMPointer streamPtr(0, bnk.data() + sr.absAddr);
-            uint8_t loopCount = sr.loopCount > 1 ? sr.loopCount : 1;
-            for (uint8_t loop = 0; loop < loopCount && ok; ++loop) {
+            FILE *fp = nullptr;
+            if (fopen_s(&fp, filename, "wb") != 0 || fp == nullptr) {
+                printf("  ERR  $%04X  cannot open %s\n", t.trackNum, filename);
+                ++nError;
+                continue;
+            }
+
+            uint32_t wavFrames = (uint32_t)totalFrames + 2;
+            uint8_t hdr[44];
+            memset(hdr, 0, sizeof(hdr));
+            uint32_t dataBytes = wavFrames * 240 * 2;
+            memcpy(&hdr[0], "RIFF\0\0\0\0WAVEfmt ", 16);
+            *reinterpret_cast<uint32_t*>(&hdr[4])  = dataBytes + 44 - 8;
+            *reinterpret_cast<uint32_t*>(&hdr[16]) = 16;
+            *reinterpret_cast<uint16_t*>(&hdr[20]) = 1;
+            *reinterpret_cast<uint16_t*>(&hdr[22]) = 1;
+            *reinterpret_cast<uint32_t*>(&hdr[24]) = 31250;
+            *reinterpret_cast<uint32_t*>(&hdr[28]) = 31250 * 2;
+            *reinterpret_cast<uint16_t*>(&hdr[32]) = 2;
+            *reinterpret_cast<uint16_t*>(&hdr[34]) = 16;
+            memcpy(&hdr[36], "data", 4);
+            *reinterpret_cast<uint32_t*>(&hdr[40]) = dataBytes;
+            bool ok = (fwrite(hdr, 44, 1, fp) == 1);
+
+            for (size_t si = 0; si < t.streams.size() && ok; ++si) {
+                auto &sr = t.streams[si];
+                DCSDecoder::ROMPointer streamPtr(0, bnk.data() + sr.absAddr);
+                uint8_t loopCount = sr.loopCount > 1 ? sr.loopCount : 1;
+                for (uint8_t loop = 0; loop < loopCount && ok; ++loop) {
+                    decoder.SoftBoot();
+                    decoder.LoadAudioStream(0, streamPtr, sr.mixLevel);
+                    for (int f = 0; f < frameCounts[si] / loopCount && ok; ++f) {
+                        int16_t buf[240];
+                        for (int s = 0; s < 240; ++s) buf[s] = decoder.GetNextSample();
+                        ok = (fwrite(buf, sizeof(buf), 1, fp) == 1);
+                    }
+                }
+            }
+            // 2 tail frames for decay
+            if (ok) {
                 decoder.SoftBoot();
-                decoder.LoadAudioStream(0, streamPtr, sr.mixLevel);
-                for (int f = 0; f < frameCounts[si] / loopCount && ok; ++f) {
+                for (int f = 0; f < 2 && ok; ++f) {
                     int16_t buf[240];
                     for (int s = 0; s < 240; ++s) buf[s] = decoder.GetNextSample();
                     ok = (fwrite(buf, sizeof(buf), 1, fp) == 1);
                 }
             }
-        }
-        // 2 tail frames of silence for decay
-        if (ok) {
-            decoder.SoftBoot();
-            for (int f = 0; f < 2 && ok; ++f) {
-                int16_t buf[240];
-                for (int s = 0; s < 240; ++s) buf[s] = decoder.GetNextSample();
-                ok = (fwrite(buf, sizeof(buf), 1, fp) == 1);
-            }
-        }
-        ok = (fclose(fp) == 0) && ok;
+            ok = (fclose(fp) == 0) && ok;
 
-        if (ok) {
-            printf("  OK   $%04X  %5d frames (%zu stream%s)  %s\n",
-                t.trackNum, totalFrames, t.streams.size(),
-                t.streams.size() == 1 ? "" : "s", filename);
-            ++nOk;
-        } else {
-            printf("  ERR  $%04X  %s\n", t.trackNum, filename);
-            ++nError;
+            if (ok) {
+                printf("  OK   $%04X  %5d frames (%zu stream%s)  %s\n",
+                    t.trackNum, totalFrames, t.streams.size(),
+                    t.streams.size() == 1 ? "" : "s", filename);
+                ++nOk;
+            } else {
+                printf("  ERR  $%04X  %s\n", t.trackNum, filename);
+                ++nError;
+            }
         }
     }
 

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -167,8 +167,152 @@ struct StreamRef {
 
 struct Track {
     int                   trackNum;
+    size_t                poff;     // file offset of the 18-byte playlist entry
     std::vector<StreamRef> streams;
 };
+
+// ---------------------------------------------------------------------------
+// Disassemble DCS track program bytecode, returning a formatted string in the
+// same style as DCSDecoder::ExplainTrackProgram / DCSExplorer -p output.
+// poff = file offset of the 18-byte playlist entry; bnkSize guards reads.
+// linePrefix is prepended to every output line (e.g. "    ").
+// ---------------------------------------------------------------------------
+static std::string disassembleProgram(
+    const uint8_t *bnk, size_t bnkSize, size_t poff, const char *linePrefix)
+{
+    std::string out;
+    size_t p = poff + BNK_PROGRAM_HDR;
+
+    uint8_t trackChannel = (poff < bnkSize) ? bnk[poff + 1] : 0;
+
+    std::string loopIndent;
+    const char *perLoopIndent = "  ";
+
+    auto appendLine = [&](const std::string &instr, const std::string &hexDesc) {
+        if (!out.empty()) out += "\n";
+        char buf[256];
+        snprintf(buf, sizeof(buf), "%-60s    // %s",
+            (loopIndent + instr).c_str(), hexDesc.c_str());
+        out += linePrefix;
+        out += buf;
+    };
+
+    for (int guard = 0; guard < 4096 && p + 2 < bnkSize; ++guard) {
+        uint16_t waitCount = (uint16_t)((bnk[p] << 8) | bnk[p+1]);  p += 2;
+        if (p >= bnkSize) break;
+        uint8_t op = bnk[p++];
+
+        std::string wait;
+        if (waitCount == 0xFFFFu)
+            wait = "Wait(Forever) ";
+        else if (waitCount != 0)
+        { char tmp[32]; snprintf(tmp, sizeof(tmp), "Wait(%u) ", waitCount); wait = tmp; }
+
+        char hex[64];
+        snprintf(hex, sizeof(hex), "%04X %02X", waitCount, op);
+        std::string hexDesc = hex;
+
+        std::string instr;
+        bool done = false;
+
+        switch (op) {
+        case 0x00:
+            instr = "End;";
+            done = true;
+            break;
+
+        case 0x01:
+            if (p + 4 >= bnkSize) { done = true; break; }
+            {
+                uint8_t  ch     = bnk[p++];
+                size_t   vs     = p;
+                uint32_t stored = read_be24(bnk + p);  p += 3;
+                uint8_t  repeat = bnk[p++];
+                uint32_t absAddr = stored + (uint32_t)vs;
+                char hx[32]; snprintf(hx, sizeof(hx), " %02X %06X %02X", ch, stored, repeat);
+                hexDesc += hx;
+                std::string chTag = (ch == trackChannel) ? "" : [&]{ char t[32]; snprintf(t, sizeof(t), "channel %d,", ch); return std::string(t); }();
+                char istr[80];
+                if (repeat == 0)
+                    snprintf(istr, sizeof(istr), "Play(%sstream $%06X, repeat forever);", chTag.c_str(), absAddr);
+                else if (repeat == 1)
+                    snprintf(istr, sizeof(istr), "Play(%sstream $%06X);", chTag.c_str(), absAddr);
+                else
+                    snprintf(istr, sizeof(istr), "Play(%sstream $%06X, repeat %d);", chTag.c_str(), absAddr, repeat);
+                instr = istr;
+            }
+            break;
+
+        case 0x02:
+            if (p < bnkSize) {
+                uint8_t ch = bnk[p++];
+                char hx[16]; snprintf(hx, sizeof(hx), " %02X", ch); hexDesc += hx;
+                char istr[48]; snprintf(istr, sizeof(istr), "Stop(channel %d);", ch);
+                instr = istr;
+            }
+            break;
+
+        case 0x07: case 0x08: case 0x09:
+            if (p + 1 < bnkSize) {
+                uint8_t ch  = bnk[p++];
+                uint8_t lvl = bnk[p++];
+                char hx[16]; snprintf(hx, sizeof(hx), " %02X %02X", ch, lvl); hexDesc += hx;
+                std::string chTag = (ch == trackChannel) ? "" : [&]{ char t[32]; snprintf(t, sizeof(t), "channel %d, ", ch); return std::string(t); }();
+                const char *verb = (op == 0x07) ? "level" : (op == 0x08) ? "increase" : "decrease";
+                char istr[80]; snprintf(istr, sizeof(istr), "SetMixingLevel(%s%s %d);", chTag.c_str(), verb, lvl);
+                instr = istr;
+            }
+            break;
+
+        case 0x0A: case 0x0B: case 0x0C:
+            if (p + 3 < bnkSize) {
+                uint8_t  ch    = bnk[p++];
+                uint8_t  lvl   = bnk[p++];
+                uint16_t steps = read_be16(bnk + p); p += 2;
+                char hx[24]; snprintf(hx, sizeof(hx), " %02X %02X %04X", ch, lvl, steps); hexDesc += hx;
+                std::string chTag = (ch == trackChannel) ? "" : [&]{ char t[32]; snprintf(t, sizeof(t), "channel %d, ", ch); return std::string(t); }();
+                const char *verb = (op == 0x0A) ? "level" : (op == 0x0B) ? "increase" : "decrease";
+                char istr[80]; snprintf(istr, sizeof(istr), "SetMixingLevel(%s%s %u, steps %u);", chTag.c_str(), verb, lvl, steps);
+                instr = istr;
+            }
+            break;
+
+        case 0x0D:
+            instr = "NOP;";
+            break;
+
+        case 0x0E:
+            if (p < bnkSize) {
+                uint8_t cnt = bnk[p++];
+                char hx[8]; snprintf(hx, sizeof(hx), " %02X", cnt); hexDesc += hx;
+                char istr[32];
+                if (cnt != 0) snprintf(istr, sizeof(istr), "Loop (%d) {", cnt);
+                else          snprintf(istr, sizeof(istr), "Loop {");
+                instr = istr;
+            }
+            break;
+
+        case 0x0F:
+            // dedent before printing the closing brace
+            if (!loopIndent.empty()) loopIndent = loopIndent.substr(2);
+            instr = "}";
+            break;
+
+        default:
+            { char istr[32]; snprintf(istr, sizeof(istr), "InvalidOpcode$%02X;", op); instr = istr; }
+            done = true;
+            break;
+        }
+
+        // For loop-end, loopIndent was already reduced above; append normally.
+        // For loop-start, append then increase indent.
+        appendLine(wait + instr, hexDesc);
+        if (op == 0x0E) loopIndent += perLoopIndent;
+
+        if (done || waitCount == 0xFFFFu) break;
+    }
+    return out;
+}
 
 // ---------------------------------------------------------------------------
 // Parse DCS track program bytecode from a BNK playlist entry.
@@ -251,12 +395,15 @@ int main(int argc, char *argv[])
     const char *lstPath  = nullptr;
     std::string outDir   = ".";
     bool samplesMode     = false;
+    bool programMode     = false;
 
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "--outdir") == 0 && i + 1 < argc) {
             outDir = argv[++i];
         } else if (strcmp(argv[i], "--samples") == 0) {
             samplesMode = true;
+        } else if (strcmp(argv[i], "--program") == 0 || strcmp(argv[i], "-p") == 0) {
+            programMode = true;
         } else if (!bnkPath) {
             bnkPath = argv[i];
         } else if (!lstPath) {
@@ -265,8 +412,9 @@ int main(int argc, char *argv[])
     }
 
     if (!bnkPath) {
-        printf("Usage: BnkExtract <file.BNK> [file.LST] [--outdir <dir>] [--samples]\n");
+        printf("Usage: BnkExtract <file.BNK> [file.LST] [--outdir <dir>] [--samples] [-p]\n");
         printf("  --samples  Write each individual stream as a separate WAV\n");
+        printf("  -p         Print track program disassembly (DCSExplorer format)\n");
         return 1;
     }
 
@@ -331,6 +479,7 @@ int main(int argc, char *argv[])
 
         Track t;
         t.trackNum = i;
+        t.poff     = poff;
         t.streams  = std::move(streams);
         tracks.push_back(t);
     }
@@ -356,6 +505,25 @@ int main(int argc, char *argv[])
     decoder.InitStandalone(DCSDecoder::OSVersion::OS95);
     decoder.SetDefaultVolume(0xFF);
     decoder.SoftBoot();
+
+    // --- print track programs if requested ---
+    if (programMode) {
+        for (auto &t : tracks) {
+            std::string name;
+            auto it = names.find(t.trackNum);
+            if (it != names.end()) name = it->second;
+
+            if (!name.empty())
+                printf("Track $%04X \"%s\"\n", t.trackNum, name.c_str());
+            else
+                printf("Track $%04X\n", t.trackNum);
+
+            std::string prog = disassembleProgram(bnk.data(), bnkSize, t.poff, "    ");
+            if (!prog.empty())
+                printf("%s\n", prog.c_str());
+            printf("\n");
+        }
+    }
 
     // --- extract each track ---
     int nOk = 0, nError = 0, nSkip = 0;

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -1,0 +1,328 @@
+// BnkExtract.cpp - Extract audio streams from DCS2 .BNK files to WAV
+//
+// Usage:
+//   BnkExtract <file.BNK> [file.LST] [--outdir <dir>]
+//
+// Parses the BNK track index, decodes each audio stream via DCSDecoderNative
+// in standalone mode (no ROM required), and writes one WAV per track.
+// If a matching .LST file is supplied, track descriptions are used as filenames.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+#include <string>
+#include <vector>
+#include <map>
+#include <algorithm>
+#include <filesystem>
+
+#include "../DCSDecoder/DCSDecoder.h"
+#include "../DCSDecoder/DCSDecoderNative.h"
+
+// ---------------------------------------------------------------------------
+// BNK file layout constants
+// ---------------------------------------------------------------------------
+
+static const size_t BNK_COUNT_OFFSET      = 0x80;  // LE uint16 - number of index slots
+static const size_t BNK_INDEX_OFFSET      = 0x86;  // LE uint32 per slot, relative to DATA_BASE
+static const size_t BNK_DATA_BASE         = 0x5FA; // start of playlist + stream data
+static const size_t BNK_PLAYLIST_STRIDE   = 18;    // bytes per playlist program entry
+static const size_t BNK_STREAM_ADDR_OFF   = 11;    // offset within playlist entry: 3-byte BE stream addr
+static const size_t BNK_FRAME_PARAM_OFF   = 16;    // offset within playlist entry: byte (unused here)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static uint16_t read_le16(const uint8_t *p) { return (uint16_t)(p[0] | (p[1] << 8)); }
+static uint32_t read_le32(const uint8_t *p) { return p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24); }
+static uint32_t read_be24(const uint8_t *p) { return (p[0]<<16) | (p[1]<<8) | p[2]; }
+static uint16_t read_be16(const uint8_t *p) { return (uint16_t)((p[0]<<8) | p[1]); }
+
+// Sanitise a description string for use as a filename component.
+static std::string sanitise(const std::string &s)
+{
+    std::string out;
+    for (char c : s) {
+        if (c == '/' || c == '\\' || c == ':' || c == '*' || c == '?' ||
+            c == '"' || c == '<'  || c == '>' || c == '|')
+            out += '_';
+        else if ((unsigned char)c < 32)
+            out += '_';
+        else
+            out += c;
+    }
+    // trim trailing spaces/underscores
+    while (!out.empty() && (out.back() == ' ' || out.back() == '_'))
+        out.pop_back();
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// LST parser  -  builds map: track_number -> description string
+// ---------------------------------------------------------------------------
+
+static std::map<int, std::string> parseLst(const char *lstPath)
+{
+    std::map<int, std::string> result;
+    FILE *fp = nullptr;
+    if (fopen_s(&fp, lstPath, "r") != 0 || fp == nullptr)
+        return result;
+
+    char line[512];
+    while (fgets(line, sizeof(line), fp)) {
+        // Lines of interest look like:
+        //   "  1    $0001   1       84.5    97.0  _ With the running one-hander"
+        // Fields: dec  $hex  ntrks  video  pinball  description...
+        int dec;
+        int hex;
+        if (sscanf_s(line, " %d $%x", &dec, &hex) == 2) {
+            // description starts after the 5th whitespace-delimited token
+            const char *p = line;
+            int tokens = 0;
+            while (*p && tokens < 5) {
+                while (*p == ' ' || *p == '\t') ++p;  // skip whitespace
+                while (*p && *p != ' ' && *p != '\t') ++p;  // skip token
+                ++tokens;
+            }
+            while (*p == ' ' || *p == '\t') ++p;  // skip whitespace before description
+            // strip trailing newline
+            std::string desc(p);
+            while (!desc.empty() && (desc.back() == '\n' || desc.back() == '\r' || desc.back() == ' '))
+                desc.pop_back();
+            // strip leading underscore+space that some entries use as a prefix
+            if (desc.size() >= 2 && desc[0] == '_' && desc[1] == ' ')
+                desc = desc.substr(2);
+            if (!desc.empty())
+                result[hex] = desc;
+        }
+    }
+    fclose(fp);
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// WAV writer  -  mirrors the approach in DCSExplorer.cpp
+// ---------------------------------------------------------------------------
+
+static bool writeWav(const char *path, DCSDecoder *decoder, uint16_t nFrames)
+{
+    // Two extra frames ensures playback tapers to silence
+    nFrames += 2;
+
+    FILE *fp = nullptr;
+    if (fopen_s(&fp, path, "wb") != 0 || fp == nullptr) {
+        printf("  ERROR: cannot open output file \"%s\" (errno %d)\n", path, errno);
+        return false;
+    }
+
+    // 44-byte RIFF/WAV header  (31250 Hz, mono, 16-bit PCM)
+    uint8_t hdr[44];
+    memset(hdr, 0, sizeof(hdr));
+    uint32_t dataBytes = (uint32_t)nFrames * 240 * 2;
+    memcpy(&hdr[0], "RIFF\0\0\0\0WAVEfmt ", 16);
+    *reinterpret_cast<uint32_t*>(&hdr[4])  = dataBytes + 44 - 8;
+    *reinterpret_cast<uint32_t*>(&hdr[16]) = 16;
+    *reinterpret_cast<uint16_t*>(&hdr[20]) = 1;
+    *reinterpret_cast<uint16_t*>(&hdr[22]) = 1;
+    *reinterpret_cast<uint32_t*>(&hdr[24]) = 31250;
+    *reinterpret_cast<uint32_t*>(&hdr[28]) = 31250 * 2;
+    *reinterpret_cast<uint16_t*>(&hdr[32]) = 2;
+    *reinterpret_cast<uint16_t*>(&hdr[34]) = 16;
+    memcpy(&hdr[36], "data", 4);
+    *reinterpret_cast<uint32_t*>(&hdr[40]) = dataBytes;
+
+    bool ok = (fwrite(hdr, 44, 1, fp) == 1);
+
+    for (uint16_t frame = 0; frame < nFrames && ok; ++frame) {
+        int16_t buf[240];
+        for (int si = 0; si < 240; ++si)
+            buf[si] = decoder->GetNextSample();
+        ok = (fwrite(buf, sizeof(buf), 1, fp) == 1);
+
+        // Cancel looping one frame before end so it tapers cleanly
+        if (frame + 2 >= nFrames)
+            decoder->ClearTracks();
+    }
+
+    ok = (fclose(fp) == 0) && ok;
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Track entry
+// ---------------------------------------------------------------------------
+
+struct Track {
+    int     trackNum;
+    uint32_t streamAddr;   // file offset into BNK
+    size_t  streamBytes;   // length derived from next-addr method
+    uint16_t nFrames;      // from first 2 bytes of stream data (BE uint16)
+};
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char *argv[])
+{
+    printf("BnkExtract - DCS2 BNK audio extractor\n\n");
+
+    // --- parse arguments ---
+    const char *bnkPath = nullptr;
+    const char *lstPath = nullptr;
+    std::string outDir  = ".";
+
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--outdir") == 0 && i + 1 < argc) {
+            outDir = argv[++i];
+        } else if (!bnkPath) {
+            bnkPath = argv[i];
+        } else if (!lstPath) {
+            lstPath = argv[i];
+        }
+    }
+
+    if (!bnkPath) {
+        printf("Usage: BnkExtract <file.BNK> [file.LST] [--outdir <dir>]\n");
+        return 1;
+    }
+
+    // --- load BNK ---
+    FILE *fp = nullptr;
+    if (fopen_s(&fp, bnkPath, "rb") != 0 || fp == nullptr) {
+        printf("ERROR: cannot open \"%s\"\n", bnkPath);
+        return 1;
+    }
+    fseek(fp, 0, SEEK_END);
+    size_t bnkSize = (size_t)ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    std::vector<uint8_t> bnk(bnkSize);
+    if (fread(bnk.data(), 1, bnkSize, fp) != bnkSize) {
+        printf("ERROR: read failed for \"%s\"\n", bnkPath);
+        fclose(fp);
+        return 1;
+    }
+    fclose(fp);
+
+    // --- validate header ---
+    if (bnkSize < BNK_DATA_BASE + 18) {
+        printf("ERROR: file too small to be a valid BNK\n");
+        return 1;
+    }
+    // BNK files start with "DCS " ASCII
+    if (bnk[0] != 'D' || bnk[1] != 'C' || bnk[2] != 'S' || bnk[3] != ' ') {
+        printf("ERROR: not a DCS BNK file (missing 'DCS ' header)\n");
+        return 1;
+    }
+
+    // Print the title string from offset 0
+    char title[64];
+    memcpy(title, bnk.data(), 63);
+    title[63] = '\0';
+    // null-terminate at first 0xFF
+    for (int i = 0; i < 63; ++i) if ((uint8_t)title[i] == 0xFF) { title[i] = '\0'; break; }
+    printf("BNK: %s\n", title);
+    printf("File: %s  (%zu bytes)\n\n", bnkPath, bnkSize);
+
+    // --- parse index ---
+    uint16_t slotCount = read_le16(bnk.data() + BNK_COUNT_OFFSET);
+    if (BNK_INDEX_OFFSET + (size_t)slotCount * 4 > bnkSize) {
+        printf("ERROR: index extends beyond file\n");
+        return 1;
+    }
+
+    // Collect valid tracks
+    std::vector<Track> tracks;
+    for (int i = 0; i < (int)slotCount; ++i) {
+        uint32_t rel = read_le32(bnk.data() + BNK_INDEX_OFFSET + i * 4);
+        if (rel == 0xFFFFFFFF) continue;
+        if (i == 0 && rel == 0) continue;  // slot 0 unused sentinel
+
+        size_t playlistOff = BNK_DATA_BASE + rel;
+        if (playlistOff + BNK_PLAYLIST_STRIDE > bnkSize) continue;
+
+        uint32_t streamAddr = read_be24(bnk.data() + playlistOff + BNK_STREAM_ADDR_OFF);
+        if (streamAddr == 0 || streamAddr >= bnkSize) continue;
+
+        uint16_t nFrames = read_be16(bnk.data() + streamAddr);
+        if (nFrames == 0) continue;  // skip anomalous/null entries
+
+        Track t;
+        t.trackNum   = i;
+        t.streamAddr = streamAddr;
+        t.nFrames    = nFrames;
+        t.streamBytes = 0;  // filled below
+        tracks.push_back(t);
+    }
+
+    if (tracks.empty()) {
+        printf("ERROR: no valid tracks found in BNK\n");
+        return 1;
+    }
+
+    // Derive stream byte lengths from sorted addresses
+    {
+        std::vector<uint32_t> addrs;
+        for (auto &t : tracks) addrs.push_back(t.streamAddr);
+        std::sort(addrs.begin(), addrs.end());
+        addrs.erase(std::unique(addrs.begin(), addrs.end()), addrs.end());
+
+        for (auto &t : tracks) {
+            auto it = std::upper_bound(addrs.begin(), addrs.end(), t.streamAddr);
+            size_t end = (it != addrs.end()) ? *it : bnkSize;
+            t.streamBytes = end - t.streamAddr;
+        }
+    }
+
+    printf("Found %zu tracks\n\n", tracks.size());
+
+    // --- load LST names ---
+    std::map<int, std::string> names;
+    if (lstPath)
+        names = parseLst(lstPath);
+
+    // --- ensure output directory exists ---
+    std::filesystem::create_directories(outDir);
+
+    // --- set up decoder ---
+    DCSDecoder::MinHost host;
+    DCSDecoderNative decoder(&host);
+    decoder.InitStandalone(DCSDecoder::OSVersion::OS95);
+    decoder.SoftBoot();
+
+    // --- extract each track ---
+    int nOk = 0, nError = 0, nSkip = 0;
+    for (auto &t : tracks) {
+        // Build output filename
+        std::string name;
+        auto it = names.find(t.trackNum);
+        if (it != names.end())
+            name = sanitise(it->second);
+        if (name.empty())
+            name = "track";
+
+        char filename[512];
+        snprintf(filename, sizeof(filename), "%s/%s_%04X.wav",
+            outDir.c_str(), name.c_str(), t.trackNum);
+
+        // Load stream into decoder
+        const uint8_t *streamData = bnk.data() + t.streamAddr;
+        DCSDecoder::ROMPointer streamPtr(0, streamData);
+        decoder.SoftBoot();
+        decoder.LoadAudioStream(0, streamPtr, 0x64);
+
+        bool ok = writeWav(filename, &decoder, t.nFrames);
+        if (ok) {
+            printf("  OK   $%04X  %5u frames  %s\n", t.trackNum, t.nFrames, filename);
+            ++nOk;
+        } else {
+            printf("  ERR  $%04X  %s\n", t.trackNum, filename);
+            ++nError;
+        }
+    }
+
+    printf("\nDone: %d written, %d errors, %d skipped\n", nOk, nError, nSkip);
+    return (nError > 0) ? 1 : 0;
+}

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -27,9 +27,10 @@ static const size_t BNK_COUNT_OFFSET      = 0x80;  // LE uint16 - number of inde
 static const size_t BNK_INDEX_OFFSET      = 0x86;  // LE uint32 per slot, relative to DATA_BASE
 static const size_t BNK_DATA_BASE         = 0x5FA; // start of playlist + stream data
 static const size_t BNK_PLAYLIST_STRIDE   = 18;    // bytes per playlist program entry
-static const size_t BNK_STREAM_ADDR_OFF   = 11;    // offset within playlist entry: 3-byte BE stream addr
-static const size_t BNK_FRAME_COUNT_OFF   = 16;    // offset within playlist entry: byte DCS frame count
-static const size_t BNK_STREAM_LEAD_BYTES = 2;     // stream data starts with 2 non-frame-count bytes to skip
+static const size_t BNK_STREAM_ADDR_OFF   = 11;    // offset within playlist entry: 3-byte BE relative stream addr
+// The stored addr is relative to the addr field's own file position (var_start = playlistOff + BNK_STREAM_ADDR_OFF).
+// absolute_stream_addr = stored_BE24 + var_start
+// The stream at absolute_stream_addr is standard DCS format: [U16 BE nFrames][16-byte header][packed bits]
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -152,8 +153,7 @@ static bool writeWav(const char *path, DCSDecoder *decoder, uint16_t nFrames)
 
 struct Track {
     int      trackNum;
-    uint32_t streamAddr;   // file offset into BNK (points 2 bytes before DCS header)
-    uint8_t  nFrames;      // frame count from playlist entry byte[16]
+    uint32_t streamAddr;   // absolute file offset of DCS stream: [U16 nFrames][16-byte hdr][data]
 };
 
 // ---------------------------------------------------------------------------
@@ -238,16 +238,16 @@ int main(int argc, char *argv[])
         size_t playlistOff = BNK_DATA_BASE + rel;
         if (playlistOff + BNK_PLAYLIST_STRIDE > bnkSize) continue;
 
-        uint32_t streamAddr = read_be24(bnk.data() + playlistOff + BNK_STREAM_ADDR_OFF);
-        if (streamAddr == 0 || streamAddr >= bnkSize) continue;
-
-        uint8_t nFrames = bnk[playlistOff + BNK_FRAME_COUNT_OFF];
-        if (nFrames == 0) continue;
+        // The stored address is relative to the address field's own file position.
+        size_t varStart = playlistOff + BNK_STREAM_ADDR_OFF;
+        uint32_t storedAddr = read_be24(bnk.data() + varStart);
+        if (storedAddr == 0) continue;
+        uint32_t streamAddr = storedAddr + (uint32_t)varStart;
+        if (streamAddr + 18 >= bnkSize) continue;
 
         Track t;
         t.trackNum   = i;
         t.streamAddr = streamAddr;
-        t.nFrames    = nFrames;
         tracks.push_back(t);
     }
 
@@ -287,32 +287,22 @@ int main(int argc, char *argv[])
         snprintf(filename, sizeof(filename), "%s/%s_%04X.wav",
             outDir.c_str(), name.c_str(), t.trackNum);
 
-        // BNK streams start with 2 non-frame-count lead bytes; the decoder
-        // expects [U16 BE nFrames][16-byte header][compressed data].
-        // Build a patched copy: replace the 2-byte lead with the real frame count,
-        // and give the decoder everything from there to end-of-file — it stops
-        // after nFrames frames regardless of buffer size.
-        if (t.streamAddr + BNK_STREAM_LEAD_BYTES >= bnkSize) {
-            printf("  SKIP $%04X  (stream out of range)\n", t.trackNum);
+        // Stream at streamAddr is standard DCS format: [U16 BE nFrames][16-byte hdr][data]
+        DCSDecoder::ROMPointer streamPtr(0, bnk.data() + t.streamAddr);
+
+        auto info = decoder.GetStreamInfo(streamPtr);
+        if (info.nFrames <= 0) {
+            printf("  SKIP $%04X  (GetStreamInfo returned 0 frames)\n", t.trackNum);
             ++nSkip;
             continue;
         }
-        const size_t headerAndDataLen = bnkSize - (t.streamAddr + BNK_STREAM_LEAD_BYTES);
-        std::vector<uint8_t> streamBuf(2 + headerAndDataLen);
-        streamBuf[0] = 0;
-        streamBuf[1] = t.nFrames;  // BE16 frame count (fits in 1 byte; high byte = 0)
-        memcpy(streamBuf.data() + 2,
-               bnk.data() + t.streamAddr + BNK_STREAM_LEAD_BYTES,
-               headerAndDataLen);
-
-        DCSDecoder::ROMPointer streamPtr(0, streamBuf.data());
 
         decoder.SoftBoot();
         decoder.LoadAudioStream(0, streamPtr, 0x64);
 
-        bool ok = writeWav(filename, &decoder, t.nFrames);
+        bool ok = writeWav(filename, &decoder, (uint16_t)info.nFrames);
         if (ok) {
-            printf("  OK   $%04X  %5d frames  %s\n", t.trackNum, t.nFrames, filename);
+            printf("  OK   $%04X  %5d frames  %s\n", t.trackNum, info.nFrames, filename);
             ++nOk;
         } else {
             printf("  ERR  $%04X  %s\n", t.trackNum, filename);

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -272,8 +272,8 @@ int main(int argc, char *argv[])
     DCSDecoder::MinHost host;
     DCSDecoderNative decoder(&host);
     decoder.InitStandalone(DCSDecoder::OSVersion::OS95);
+    decoder.SetDefaultVolume(0xFF);
     decoder.SoftBoot();
-    decoder.SetMasterVolume(0xFF);
 
     // --- extract each track ---
     int nOk = 0, nError = 0, nSkip = 0;

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -154,6 +154,7 @@ static bool writeWav(const char *path, DCSDecoder *decoder, uint16_t nFrames)
 struct Track {
     int      trackNum;
     uint32_t streamAddr;   // absolute file offset of DCS stream: [U16 nFrames][16-byte hdr][data]
+    uint8_t  mixLevel;     // mixing level from playlist entry byte[6]
 };
 
 // ---------------------------------------------------------------------------
@@ -248,6 +249,7 @@ int main(int argc, char *argv[])
         Track t;
         t.trackNum   = i;
         t.streamAddr = streamAddr;
+        t.mixLevel   = bnk[playlistOff + 6];  // byte[6] = channel mixing level
         tracks.push_back(t);
     }
 
@@ -271,6 +273,7 @@ int main(int argc, char *argv[])
     DCSDecoderNative decoder(&host);
     decoder.InitStandalone(DCSDecoder::OSVersion::OS95);
     decoder.SoftBoot();
+    decoder.SetMasterVolume(0xFF);
 
     // --- extract each track ---
     int nOk = 0, nError = 0, nSkip = 0;
@@ -298,7 +301,7 @@ int main(int argc, char *argv[])
         }
 
         decoder.SoftBoot();
-        decoder.LoadAudioStream(0, streamPtr, 0x64);
+        decoder.LoadAudioStream(0, streamPtr, t.mixLevel);
 
         bool ok = writeWav(filename, &decoder, (uint16_t)info.nFrames);
         if (ok) {

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -143,7 +143,7 @@ static bool writeWav(const char *path, DCSDecoder *decoder, uint16_t nFrames)
 
         // Cancel looping one frame before end so it tapers cleanly
         if (frame + 2 >= nFrames)
-            decoder->ClearTracks();
+            decoder->SoftBoot();
     }
 
     ok = (fclose(fp) == 0) && ok;

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -24,14 +24,21 @@
 // ---------------------------------------------------------------------------
 
 static const size_t BNK_COUNT_OFFSET      = 0x80;  // LE uint16 - number of index slots
-static const size_t BNK_INDEX_OFFSET      = 0x86;  // LE uint32 per slot, relative to DATA_BASE
-static const size_t BNK_DATA_BASE         = 0x5FA; // start of playlist + stream data
-static const size_t BNK_PLAYLIST_STRIDE   = 18;    // bytes per playlist program entry
-// Stream addresses are found by scanning for the fix_stream_addr pattern:
-//   [2 lead bytes] 01 00 [3-byte BE relative addr] 01
-// absolute_stream_addr = stored_BE24 + var_start  (var_start = position after "01 00")
-// The stream at that address is standard DCS format: [U16 BE nFrames][16-byte header][packed bits]
-// The slot->stream mapping uses rel/18 as index into the ordered stream table.
+static const size_t BNK_INDEX_OFFSET      = 0x86;  // LE uint32 per slot, relative to data base
+// Data base (playlist table start) = BNK_INDEX_OFFSET + slotCount * 4  (computed at runtime)
+static const size_t BNK_PLAYLIST_STRIDE   = 18;    // bytes per playlist entry
+static const size_t BNK_PROGRAM_HDR       = 2;     // bytes before DCS bytecode in each playlist entry
+// Each playlist entry: [2-byte prefix: type, channel] [DCS track program bytecode]
+// Bytecode format: [U16 BE countPrefix][U8 opcode][args] ...
+//   0x00 = Stop
+//   0x01 = Play  [U8 ch][U24 BE relative stream addr][U8 loop]
+//   0x07-0x09 = Mixing level set   [U8 ch][U8 val]
+//   0x0A-0x0C = Mixing level fade  [U8 ch][U8 val][U16 steps]
+//   0x0D = NOP
+//   0x0E = Loop start  [U8 count]
+//   0x0F = Loop end
+// Stream addr in opcode 0x01 is relative to its own 3-byte field position.
+// Stream is standard DCS: [U16 BE nFrames][16-byte header][packed bits]
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -105,58 +112,87 @@ static std::map<int, std::string> parseLst(const char *lstPath)
 }
 
 // ---------------------------------------------------------------------------
-// WAV writer  -  mirrors the approach in DCSExplorer.cpp
+// Track entry - one or more streams played sequentially
 // ---------------------------------------------------------------------------
 
-static bool writeWav(const char *path, DCSDecoder *decoder, uint16_t nFrames)
-{
-    // Two extra frames ensures playback tapers to silence
-    nFrames += 2;
-
-    FILE *fp = nullptr;
-    if (fopen_s(&fp, path, "wb") != 0 || fp == nullptr) {
-        printf("  ERROR: cannot open output file \"%s\" (errno %d)\n", path, errno);
-        return false;
-    }
-
-    // 44-byte RIFF/WAV header  (31250 Hz, mono, 16-bit PCM)
-    uint8_t hdr[44];
-    memset(hdr, 0, sizeof(hdr));
-    uint32_t dataBytes = (uint32_t)nFrames * 240 * 2;
-    memcpy(&hdr[0], "RIFF\0\0\0\0WAVEfmt ", 16);
-    *reinterpret_cast<uint32_t*>(&hdr[4])  = dataBytes + 44 - 8;
-    *reinterpret_cast<uint32_t*>(&hdr[16]) = 16;
-    *reinterpret_cast<uint16_t*>(&hdr[20]) = 1;
-    *reinterpret_cast<uint16_t*>(&hdr[22]) = 1;
-    *reinterpret_cast<uint32_t*>(&hdr[24]) = 31250;
-    *reinterpret_cast<uint32_t*>(&hdr[28]) = 31250 * 2;
-    *reinterpret_cast<uint16_t*>(&hdr[32]) = 2;
-    *reinterpret_cast<uint16_t*>(&hdr[34]) = 16;
-    memcpy(&hdr[36], "data", 4);
-    *reinterpret_cast<uint32_t*>(&hdr[40]) = dataBytes;
-
-    bool ok = (fwrite(hdr, 44, 1, fp) == 1);
-
-    for (uint16_t frame = 0; frame < nFrames && ok; ++frame) {
-        int16_t buf[240];
-        for (int si = 0; si < 240; ++si)
-            buf[si] = decoder->GetNextSample();
-        ok = (fwrite(buf, sizeof(buf), 1, fp) == 1);
-    }
-
-    ok = (fclose(fp) == 0) && ok;
-    return ok;
-}
-
-// ---------------------------------------------------------------------------
-// Track entry
-// ---------------------------------------------------------------------------
+struct StreamRef {
+    uint32_t absAddr;   // absolute file offset of DCS stream
+    uint8_t  mixLevel;
+    uint8_t  loopCount; // 0 = play once (stored as 1 in bytecode), >1 = repeat N times
+};
 
 struct Track {
-    int      trackNum;
-    uint32_t streamAddr;   // absolute file offset of DCS stream: [U16 nFrames][16-byte hdr][data]
-    uint8_t  mixLevel;     // mixing level from playlist entry byte[6]
+    int                   trackNum;
+    std::vector<StreamRef> streams;
 };
+
+// ---------------------------------------------------------------------------
+// Parse DCS track program bytecode from a BNK playlist entry.
+// Returns list of stream references in play order (infinite loops unwound once).
+// poff = file offset of the 18-byte entry; bnkSize guards reads.
+// ---------------------------------------------------------------------------
+static std::vector<StreamRef> parseProgram(
+    const uint8_t *bnk, size_t bnkSize, size_t poff)
+{
+    std::vector<StreamRef> result;
+    size_t p = poff + BNK_PROGRAM_HDR;  // skip 2-byte prefix
+
+    // Default mix level from byte[6] of entry (before bytecode)
+    uint8_t defaultMix = (poff + 6 < bnkSize) ? bnk[poff + 6] : 0x64;
+    uint8_t curMix = defaultMix;
+
+    int loopDepth = 0;
+    for (int guard = 0; guard < 4096 && p + 2 < bnkSize; ++guard) {
+        uint16_t cp  = (uint16_t)((bnk[p] << 8) | bnk[p+1]);  p += 2;
+        if (cp == 0xFFFF) break;
+        if (p >= bnkSize) break;
+        uint8_t op = bnk[p++];
+
+        switch (op) {
+        case 0x00:  // Stop
+            return result;
+
+        case 0x01:  // Play stream
+            if (p + 4 >= bnkSize) return result;
+            {
+                uint8_t  ch   = bnk[p++];  (void)ch;
+                size_t   vs   = p;
+                uint32_t stored = read_be24(bnk + p);  p += 3;
+                uint8_t  loop = bnk[p++];
+                uint32_t abs  = stored + (uint32_t)vs;
+                if (abs + 18 < bnkSize) {
+                    uint16_t nf = read_be16(bnk + abs);
+                    if (nf > 0 && nf <= 2000)
+                        result.push_back({ abs, curMix, loop });
+                }
+            }
+            break;
+
+        case 0x07: case 0x08: case 0x09:  // Mix level set
+            if (p + 1 < bnkSize) { p++; curMix = bnk[p++]; }
+            break;
+
+        case 0x0A: case 0x0B: case 0x0C:  // Mix level fade
+            if (p + 3 < bnkSize) { p++; curMix = bnk[p++]; p += 2; }
+            break;
+
+        case 0x0D:  // NOP
+            break;
+
+        case 0x0E:  // Loop start
+            if (p < bnkSize) { p++; loopDepth++; }
+            break;
+
+        case 0x0F:  // Loop end
+            loopDepth = (loopDepth > 0) ? loopDepth - 1 : 0;
+            break;
+
+        default:
+            return result;  // unknown opcode — stop parsing
+        }
+    }
+    return result;
+}
 
 // ---------------------------------------------------------------------------
 // main
@@ -204,7 +240,7 @@ int main(int argc, char *argv[])
     fclose(fp);
 
     // --- validate header ---
-    if (bnkSize < BNK_DATA_BASE + 18) {
+    if (bnkSize < 0x100) {
         printf("ERROR: file too small to be a valid BNK\n");
         return 1;
     }
@@ -230,45 +266,24 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    // Build stream table by scanning for the fix_stream_addr pattern:
-    // [2 lead bytes] 01 00 [3-byte BE relative addr] 01
-    // absolute_addr = stored_BE24 + var_start
-    struct StreamEntry { uint32_t absAddr; uint8_t mixLevel; };
-    std::vector<StreamEntry> streamTable;
-    {
-        const uint8_t *p = bnk.data();
-        for (size_t k = 2; k + 6 < bnkSize; ++k) {
-            if (p[k] != 0x01 || p[k+1] != 0x00) continue;
-            if (p[k+5] != 0x01) continue;
-            size_t varStart = k + 2;
-            uint32_t stored = read_be24(p + varStart);
-            if (stored == 0) continue;
-            uint32_t absAddr = stored + (uint32_t)varStart;
-            if (absAddr + 18 >= bnkSize) continue;
-            // Validate: first 2 bytes at absAddr should be a plausible frame count
-            uint16_t nf = read_be16(p + absAddr);
-            if (nf == 0 || nf > 2000) continue;
-            StreamEntry se;
-            se.absAddr  = absAddr;
-            se.mixLevel = p[k - 3];  // byte[6] of 18-byte entry = 3 bytes before "01 00"
-            streamTable.push_back(se);
-            k += 5;  // skip past this match
-        }
-    }
+    // Data base = right after the index table
+    size_t dataBase = BNK_INDEX_OFFSET + (size_t)slotCount * 4;
 
-    // Collect valid tracks: slot -> stream via rel/18 as index into streamTable
+    // Collect valid tracks by parsing each playlist entry's bytecode
     std::vector<Track> tracks;
     for (int i = 0; i < (int)slotCount; ++i) {
         uint32_t rel = read_le32(bnk.data() + BNK_INDEX_OFFSET + i * 4);
         if (rel == 0xFFFFFFFF) continue;
 
-        size_t streamIdx = rel / BNK_PLAYLIST_STRIDE;
-        if (streamIdx >= streamTable.size()) continue;
+        size_t poff = dataBase + rel;
+        if (poff + BNK_PROGRAM_HDR + 3 >= bnkSize) continue;
+
+        auto streams = parseProgram(bnk.data(), bnkSize, poff);
+        if (streams.empty()) continue;
 
         Track t;
-        t.trackNum   = i;
-        t.streamAddr = streamTable[streamIdx].absAddr;
-        t.mixLevel   = streamTable[streamIdx].mixLevel;
+        t.trackNum = i;
+        t.streams  = std::move(streams);
         tracks.push_back(t);
     }
 
@@ -309,22 +324,80 @@ int main(int argc, char *argv[])
         snprintf(filename, sizeof(filename), "%s/%s_%04X.wav",
             outDir.c_str(), name.c_str(), t.trackNum);
 
-        // Stream at streamAddr is standard DCS format: [U16 BE nFrames][16-byte hdr][data]
-        DCSDecoder::ROMPointer streamPtr(0, bnk.data() + t.streamAddr);
-
-        auto info = decoder.GetStreamInfo(streamPtr);
-        if (info.nFrames <= 0) {
-            printf("  SKIP $%04X  (GetStreamInfo returned 0 frames)\n", t.trackNum);
+        // Get frame counts for all streams in this track
+        std::vector<int> frameCounts;
+        int totalFrames = 0;
+        bool valid = true;
+        for (auto &sr : t.streams) {
+            DCSDecoder::ROMPointer streamPtr(0, bnk.data() + sr.absAddr);
+            auto info = decoder.GetStreamInfo(streamPtr);
+            if (info.nFrames <= 0) { valid = false; break; }
+            int n = info.nFrames * (sr.loopCount > 1 ? sr.loopCount : 1);
+            frameCounts.push_back(n);
+            totalFrames += n;
+        }
+        if (!valid || totalFrames <= 0) {
+            printf("  SKIP $%04X  (no valid frames)\n", t.trackNum);
             ++nSkip;
             continue;
         }
 
-        decoder.SoftBoot();
-        decoder.LoadAudioStream(0, streamPtr, t.mixLevel);
+        // Write WAV: streams decoded back-to-back
+        FILE *fp = nullptr;
+        if (fopen_s(&fp, filename, "wb") != 0 || fp == nullptr) {
+            printf("  ERR  $%04X  cannot open %s\n", t.trackNum, filename);
+            ++nError;
+            continue;
+        }
 
-        bool ok = writeWav(filename, &decoder, (uint16_t)info.nFrames);
+        // Write WAV header with total frame count + 2 tail frames
+        uint32_t wavFrames = (uint32_t)totalFrames + 2;
+        uint8_t hdr[44];
+        memset(hdr, 0, sizeof(hdr));
+        uint32_t dataBytes = wavFrames * 240 * 2;
+        memcpy(&hdr[0], "RIFF\0\0\0\0WAVEfmt ", 16);
+        *reinterpret_cast<uint32_t*>(&hdr[4])  = dataBytes + 44 - 8;
+        *reinterpret_cast<uint32_t*>(&hdr[16]) = 16;
+        *reinterpret_cast<uint16_t*>(&hdr[20]) = 1;
+        *reinterpret_cast<uint16_t*>(&hdr[22]) = 1;
+        *reinterpret_cast<uint32_t*>(&hdr[24]) = 31250;
+        *reinterpret_cast<uint32_t*>(&hdr[28]) = 31250 * 2;
+        *reinterpret_cast<uint16_t*>(&hdr[32]) = 2;
+        *reinterpret_cast<uint16_t*>(&hdr[34]) = 16;
+        memcpy(&hdr[36], "data", 4);
+        *reinterpret_cast<uint32_t*>(&hdr[40]) = dataBytes;
+        bool ok = (fwrite(hdr, 44, 1, fp) == 1);
+
+        // Decode each stream in sequence
+        for (size_t si = 0; si < t.streams.size() && ok; ++si) {
+            auto &sr = t.streams[si];
+            DCSDecoder::ROMPointer streamPtr(0, bnk.data() + sr.absAddr);
+            uint8_t loopCount = sr.loopCount > 1 ? sr.loopCount : 1;
+            for (uint8_t loop = 0; loop < loopCount && ok; ++loop) {
+                decoder.SoftBoot();
+                decoder.LoadAudioStream(0, streamPtr, sr.mixLevel);
+                for (int f = 0; f < frameCounts[si] / loopCount && ok; ++f) {
+                    int16_t buf[240];
+                    for (int s = 0; s < 240; ++s) buf[s] = decoder.GetNextSample();
+                    ok = (fwrite(buf, sizeof(buf), 1, fp) == 1);
+                }
+            }
+        }
+        // 2 tail frames of silence for decay
         if (ok) {
-            printf("  OK   $%04X  %5d frames  %s\n", t.trackNum, info.nFrames, filename);
+            decoder.SoftBoot();
+            for (int f = 0; f < 2 && ok; ++f) {
+                int16_t buf[240];
+                for (int s = 0; s < 240; ++s) buf[s] = decoder.GetNextSample();
+                ok = (fwrite(buf, sizeof(buf), 1, fp) == 1);
+            }
+        }
+        ok = (fclose(fp) == 0) && ok;
+
+        if (ok) {
+            printf("  OK   $%04X  %5d frames (%zu stream%s)  %s\n",
+                t.trackNum, totalFrames, t.streams.size(),
+                t.streams.size() == 1 ? "" : "s", filename);
             ++nOk;
         } else {
             printf("  ERR  $%04X  %s\n", t.trackNum, filename);

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -14,7 +14,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <algorithm>
 #include <filesystem>
 
 #include "../DCSDecoder/DCSDecoder.h"
@@ -155,7 +154,6 @@ struct Track {
     int      trackNum;
     uint32_t streamAddr;   // file offset into BNK (points 2 bytes before DCS header)
     uint8_t  nFrames;      // frame count from playlist entry byte[16]
-    size_t   streamBytes;  // length derived from next-addr method
 };
 
 // ---------------------------------------------------------------------------
@@ -247,30 +245,15 @@ int main(int argc, char *argv[])
         if (nFrames == 0) continue;
 
         Track t;
-        t.trackNum    = i;
-        t.streamAddr  = streamAddr;
-        t.nFrames     = nFrames;
-        t.streamBytes = 0;  // filled below
+        t.trackNum   = i;
+        t.streamAddr = streamAddr;
+        t.nFrames    = nFrames;
         tracks.push_back(t);
     }
 
     if (tracks.empty()) {
         printf("ERROR: no valid tracks found in BNK\n");
         return 1;
-    }
-
-    // Derive stream byte lengths from sorted addresses
-    {
-        std::vector<uint32_t> addrs;
-        for (auto &t : tracks) addrs.push_back(t.streamAddr);
-        std::sort(addrs.begin(), addrs.end());
-        addrs.erase(std::unique(addrs.begin(), addrs.end()), addrs.end());
-
-        for (auto &t : tracks) {
-            auto it = std::upper_bound(addrs.begin(), addrs.end(), t.streamAddr);
-            size_t end = (it != addrs.end()) ? *it : bnkSize;
-            t.streamBytes = end - t.streamAddr;
-        }
     }
 
     printf("Found %zu tracks\n\n", tracks.size());
@@ -306,13 +289,15 @@ int main(int argc, char *argv[])
 
         // BNK streams start with 2 non-frame-count lead bytes; the decoder
         // expects [U16 BE nFrames][16-byte header][compressed data].
-        // Build a patched copy: replace the 2-byte lead with the real frame count.
+        // Build a patched copy: replace the 2-byte lead with the real frame count,
+        // and give the decoder everything from there to end-of-file — it stops
+        // after nFrames frames regardless of buffer size.
         if (t.streamAddr + BNK_STREAM_LEAD_BYTES >= bnkSize) {
             printf("  SKIP $%04X  (stream out of range)\n", t.trackNum);
             ++nSkip;
             continue;
         }
-        const size_t headerAndDataLen = t.streamBytes - BNK_STREAM_LEAD_BYTES;
+        const size_t headerAndDataLen = bnkSize - (t.streamAddr + BNK_STREAM_LEAD_BYTES);
         std::vector<uint8_t> streamBuf(2 + headerAndDataLen);
         streamBuf[0] = 0;
         streamBuf[1] = t.nFrames;  // BE16 frame count (fits in 1 byte; high byte = 0)

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -368,29 +368,39 @@ int main(int argc, char *argv[])
             name = "track";
 
         if (samplesMode) {
-            // Write each stream in the track as a separate WAV
+            // Write each unique stream address as a separate WAV, numbered in
+            // first-appearance order (duplicates within a track are skipped).
+            std::vector<uint32_t> seen;
+            size_t sampleNum = 0;
             for (size_t si = 0; si < t.streams.size(); ++si) {
                 auto &sr = t.streams[si];
+                // Skip duplicate stream addresses within this track
+                bool dup = false;
+                for (auto a : seen) if (a == sr.absAddr) { dup = true; break; }
+                if (dup) continue;
+                seen.push_back(sr.absAddr);
+                ++sampleNum;
+
                 DCSDecoder::ROMPointer streamPtr(0, bnk.data() + sr.absAddr);
                 auto info = decoder.GetStreamInfo(streamPtr);
                 if (info.nFrames <= 0) {
-                    printf("  SKIP $%04X/%zu  (0 frames)\n", t.trackNum, si + 1);
+                    printf("  SKIP $%04X/%zu  (0 frames)\n", t.trackNum, sampleNum);
                     ++nSkip;
                     continue;
                 }
 
                 char filename[512];
                 snprintf(filename, sizeof(filename), "%s/%s_%04X_%zu.wav",
-                    outDir.c_str(), name.c_str(), t.trackNum, si + 1);
+                    outDir.c_str(), name.c_str(), t.trackNum, sampleNum);
 
                 bool ok = writeOneWav(filename, decoder, bnk.data(),
                                       sr.absAddr, sr.mixLevel, info.nFrames);
                 if (ok) {
                     printf("  OK   $%04X/%zu  %5d frames  %s\n",
-                        t.trackNum, si + 1, info.nFrames, filename);
+                        t.trackNum, sampleNum, info.nFrames, filename);
                     ++nOk;
                 } else {
-                    printf("  ERR  $%04X/%zu  %s\n", t.trackNum, si + 1, filename);
+                    printf("  ERR  $%04X/%zu  %s\n", t.trackNum, sampleNum, filename);
                     ++nError;
                 }
             }

--- a/BnkExtract/BnkExtract.cpp
+++ b/BnkExtract/BnkExtract.cpp
@@ -29,7 +29,8 @@ static const size_t BNK_INDEX_OFFSET      = 0x86;  // LE uint32 per slot, relati
 static const size_t BNK_DATA_BASE         = 0x5FA; // start of playlist + stream data
 static const size_t BNK_PLAYLIST_STRIDE   = 18;    // bytes per playlist program entry
 static const size_t BNK_STREAM_ADDR_OFF   = 11;    // offset within playlist entry: 3-byte BE stream addr
-static const size_t BNK_FRAME_PARAM_OFF   = 16;    // offset within playlist entry: byte (unused here)
+static const size_t BNK_FRAME_COUNT_OFF   = 16;    // offset within playlist entry: byte DCS frame count
+static const size_t BNK_STREAM_LEAD_BYTES = 2;     // stream data starts with 2 non-frame-count bytes to skip
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -152,7 +153,8 @@ static bool writeWav(const char *path, DCSDecoder *decoder, uint16_t nFrames)
 
 struct Track {
     int      trackNum;
-    uint32_t streamAddr;   // file offset into BNK
+    uint32_t streamAddr;   // file offset into BNK (points 2 bytes before DCS header)
+    uint8_t  nFrames;      // frame count from playlist entry byte[16]
     size_t   streamBytes;  // length derived from next-addr method
 };
 
@@ -241,9 +243,13 @@ int main(int argc, char *argv[])
         uint32_t streamAddr = read_be24(bnk.data() + playlistOff + BNK_STREAM_ADDR_OFF);
         if (streamAddr == 0 || streamAddr >= bnkSize) continue;
 
+        uint8_t nFrames = bnk[playlistOff + BNK_FRAME_COUNT_OFF];
+        if (nFrames == 0) continue;
+
         Track t;
         t.trackNum    = i;
         t.streamAddr  = streamAddr;
+        t.nFrames     = nFrames;
         t.streamBytes = 0;  // filled below
         tracks.push_back(t);
     }
@@ -298,24 +304,30 @@ int main(int argc, char *argv[])
         snprintf(filename, sizeof(filename), "%s/%s_%04X.wav",
             outDir.c_str(), name.c_str(), t.trackNum);
 
-        // Load stream into decoder
-        const uint8_t *streamData = bnk.data() + t.streamAddr;
-        DCSDecoder::ROMPointer streamPtr(0, streamData);
-
-        // Use GetStreamInfo for the authoritative frame count
-        auto info = decoder.GetStreamInfo(streamPtr);
-        if (info.nFrames <= 0) {
-            printf("  SKIP $%04X  (GetStreamInfo returned 0 frames)\n", t.trackNum);
+        // BNK streams start with 2 non-frame-count lead bytes; the decoder
+        // expects [U16 BE nFrames][16-byte header][compressed data].
+        // Build a patched copy: replace the 2-byte lead with the real frame count.
+        if (t.streamAddr + BNK_STREAM_LEAD_BYTES >= bnkSize) {
+            printf("  SKIP $%04X  (stream out of range)\n", t.trackNum);
             ++nSkip;
             continue;
         }
+        const size_t headerAndDataLen = t.streamBytes - BNK_STREAM_LEAD_BYTES;
+        std::vector<uint8_t> streamBuf(2 + headerAndDataLen);
+        streamBuf[0] = 0;
+        streamBuf[1] = t.nFrames;  // BE16 frame count (fits in 1 byte; high byte = 0)
+        memcpy(streamBuf.data() + 2,
+               bnk.data() + t.streamAddr + BNK_STREAM_LEAD_BYTES,
+               headerAndDataLen);
+
+        DCSDecoder::ROMPointer streamPtr(0, streamBuf.data());
 
         decoder.SoftBoot();
         decoder.LoadAudioStream(0, streamPtr, 0x64);
 
-        bool ok = writeWav(filename, &decoder, (uint16_t)info.nFrames);
+        bool ok = writeWav(filename, &decoder, t.nFrames);
         if (ok) {
-            printf("  OK   $%04X  %5d frames  %s\n", t.trackNum, info.nFrames, filename);
+            printf("  OK   $%04X  %5d frames  %s\n", t.trackNum, t.nFrames, filename);
             ++nOk;
         } else {
             printf("  ERR  $%04X  %s\n", t.trackNum, filename);

--- a/BnkExtract/BnkExtract.vcxproj
+++ b/BnkExtract/BnkExtract.vcxproj
@@ -149,6 +149,11 @@
   <ItemGroup>
     <ClCompile Include="BnkExtract.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DCSDecoder\DCSDecoder.vcxproj">
+      <Project>{0E7A7B73-7B39-4C7E-BE58-E485DBC6DF63}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/BnkExtract/BnkExtract.vcxproj
+++ b/BnkExtract/BnkExtract.vcxproj
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}</ProjectGuid>
+    <RootNamespace>BnkExtract</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LibraryPath>$(SolutionDir)$(Platform)\$(Configuration);$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LibraryPath>$(SolutionDir)$(Platform)\$(Configuration);$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LibraryPath>$(SolutionDir)$(Platform)\$(Configuration);$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LibraryPath>$(SolutionDir)$(Platform)\$(Configuration);$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="BnkExtract.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DCSEncoder/DCSCompiler.cpp
+++ b/DCSEncoder/DCSCompiler.cpp
@@ -275,6 +275,31 @@ DCSCompiler::Stream *DCSCompiler::EncodeFile(Stream *replaces,
 		}
 	}
 
+	// Build a cache key from the canonical file path + all compression params,
+	// so that the same file with the same settings is only encoded once.
+	std::string cacheKey;
+	if (replaces == nullptr)
+	{
+		std::error_code ec;
+		auto canonical = std::filesystem::canonical(streamFile, ec);
+		auto keyPath = ec ? streamFile : canonical.string();
+		cacheKey = DCSEncoder::format("%s|%04x|%d|%d|%.6f|%d|%.6f|%.6f",
+			keyPath.c_str(),
+			params.formatVersion,
+			params.streamFormatType,
+			params.streamFormatSubType,
+			params.powerBandCutoff,
+			params.targetBitRate,
+			params.minimumDynamicRange,
+			params.maximumQuantizationError);
+
+		if (auto it = streamsByFileAndParams.find(cacheKey); it != streamsByFileAndParams.end())
+		{
+			Status(false, "Reusing cached encoding of %s", streamFile.c_str());
+			return it->second;
+		}
+	}
+
 	// establish the new encoding parameters
 	encoder.compressionParams = params;
 
@@ -303,6 +328,10 @@ DCSCompiler::Stream *DCSCompiler::EncodeFile(Stream *replaces,
 
 		// hand ownership of the new DCS object to the new stream entry
 		stream->Store(dcsObj);
+
+		// add to the file+params cache so subsequent references reuse this encoding
+		if (!cacheKey.empty())
+			streamsByFileAndParams.emplace(cacheKey, stream);
 
 		// log progress
 		int uncompressedBytes = dcsObj.nFrames * 240 * 2;

--- a/DCSEncoder/DCSCompiler.cpp
+++ b/DCSEncoder/DCSCompiler.cpp
@@ -2125,6 +2125,21 @@ bool DCSCompiler::GenerateROM(const char *outZipFile,
 			while (((p - data.get()) & 3) != 0)
 				++p;
 		}
+
+		// Ensure the stream preamble won't cross a ROM bank boundary.
+		// The ADSP-2105 firmware reads the ROM through a sliding bank
+		// window (4KB on original DCS boards, 2KB on DCS-95).  If the
+		// preamble of a stream crosses a bank boundary, reads overflow
+		// past the end of the window into the memory-mapped register
+		// area at DM($3000+), returning register values instead of ROM
+		// data and corrupting the stream header.  Pad forward to the
+		// next bank boundary when necessary.
+		void BankAlignFreePointer(size_t bankSize, size_t preambleBytes)
+		{
+			size_t pageOff = static_cast<size_t>(p - data.get()) & (bankSize - 1);
+			if (pageOff + preambleBytes > bankSize)
+				p += bankSize - pageOff;
+		}
 	};
 
 	std::list<ROMImage> newRoms;
@@ -2602,7 +2617,13 @@ bool DCSCompiler::GenerateROM(const char *outZipFile,
 		// the free pointer even-aligned after placing each stream.
 		// OS93a Type 1 streams require ODD alignment, which means
 		// we have to add one byte of padding before the stream.
-		size_t sizeNeeded = s->nBytes;
+		//
+		// We also need to account for potential bank-alignment
+		// padding (see BankAlignFreePointer).  The worst case is
+		// preambleBytes-1 extra bytes needed.
+		const size_t bankSize = (protoRomHWVer == DCSDecoder::HWVersion::DCS95) ? 0x800 : 0x1000;
+		const size_t preambleBytes = (protoRomOSVer == DCSDecoder::OSVersion::OS93a && s->GetStreamType() == 1) ? 3 : 18;
+		size_t sizeNeeded = s->nBytes + (preambleBytes - 1);
 		bool oddAligned = false;
 		if (protoRomOSVer == DCSDecoder::OSVersion::OS93a && s->GetStreamType() == 1)
 		{
@@ -2668,6 +2689,9 @@ bool DCSCompiler::GenerateROM(const char *outZipFile,
 		// of padding before placing the stream.
 		if (oddAligned)
 			bestChip->p += 1;
+
+		// Ensure the stream preamble won't cross a ROM bank boundary.
+		bestChip->BankAlignFreePointer(bankSize, preambleBytes);
 
 		// record the stream's newly assigned address
 		s->romAddr.chipNo = bestChip->chipNum;

--- a/DCSEncoder/DCSCompiler.h
+++ b/DCSEncoder/DCSCompiler.h
@@ -439,6 +439,11 @@ public:
 	// Streams by scripting name
 	std::unordered_map<std::string, Stream*> streamsByName;
 
+	// Streams by canonical file path + compression params.  This deduplicates
+	// encode jobs so that the same file referenced under different script names
+	// (or inline in Play statements) is only encoded once per unique param set.
+	std::unordered_map<std::string, Stream*> streamsByFileAndParams;
+
 	// Streams by prototype ROM address.  This indexes streams imported
 	// from the prototype ROM by their 24-bit linear ROM addresses.
 	std::unordered_map<uint32_t, Stream*> streamsByProtoAddr;

--- a/DCSExplorer.sln
+++ b/DCSExplorer.sln
@@ -30,6 +30,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DCSExplorer", "DCSExplorer\
 		{B49E0694-D6E5-4C79-A524-C5D86553597E} = {B49E0694-D6E5-4C79-A524-C5D86553597E}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BnkExtract", "BnkExtract\BnkExtract.vcxproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0E7A7B73-7B39-4C7E-BE58-E485DBC6DF63} = {0E7A7B73-7B39-4C7E-BE58-E485DBC6DF63}
+	EndProjectSection
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HiResTimer", "HiResTimer\HiResTimer.vcxproj", "{192D6309-D38E-4F66-BA6F-951B659D9A37}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libnyquist", "libnyquist\libnyquist.vcxproj", "{436D0FAB-C75A-3EB1-9814-5C4AFA35F889}"
@@ -123,6 +128,14 @@ Global
 		{02E448ED-44A0-4C78-B476-9D7CE424F362}.Release|x64.Build.0 = Release|x64
 		{02E448ED-44A0-4C78-B476-9D7CE424F362}.Release|x86.ActiveCfg = Release|Win32
 		{02E448ED-44A0-4C78-B476-9D7CE424F362}.Release|x86.Build.0 = Release|Win32
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x86.ActiveCfg = Debug|Win32
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x86.Build.0 = Debug|Win32
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|x64
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.ActiveCfg = Release|Win32
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/check_alignment.py
+++ b/check_alignment.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Check DCS stream address alignment across both NBA ROM sets.
+Looks for 2-byte, 4-byte, and 8-byte alignment violations on every
+stream referenced by a track program.
+"""
+
+import struct
+import sys
+import os
+
+ROM_SIZE = 0x100000  # 1MB per chip
+
+def load_roms(directory):
+    """Load u2..u6 (or however many exist) from a directory.
+    Accepts u{n}.bin/.ROM, U{n}.bin/.ROM, or *.u{n} filename patterns."""
+    roms = {}
+    for i in range(2, 10):
+        candidates = []
+        # u2.bin / U2.ROM style
+        for prefix in (f"u{i}", f"U{i}"):
+            for ext in ("bin", "BIN", "rom", "ROM"):
+                candidates.append(os.path.join(directory, f"{prefix}.{ext}"))
+        # anything.u2 / anything.U2 style
+        for entry in os.listdir(directory):
+            low = entry.lower()
+            if low.endswith(f".u{i}"):
+                candidates.append(os.path.join(directory, entry))
+        for path in candidates:
+            if os.path.exists(path):
+                with open(path, "rb") as f:
+                    data = f.read()
+                roms[i - 2] = data  # chip index 0 = U2
+                break
+    return roms
+
+def u8(data, off):  return data[off]
+def u16be(data, off): return struct.unpack_from(">H", data, off)[0]
+def u24be(data, off):
+    return (data[off] << 16) | (data[off+1] << 8) | data[off+2]
+
+def make_rom_pointer(roms, linear_addr):
+    """Resolve a 24-bit linear ROM address to (chip_index, offset)."""
+    chip = (linear_addr >> 20) & 0x07
+    offset = linear_addr & 0x0FFFFF
+    return chip, offset
+
+def read_at(roms, linear_addr, n):
+    """Read n bytes from a linear ROM address."""
+    chip, off = make_rom_pointer(roms, linear_addr)
+    if chip not in roms:
+        return None
+    data = roms[chip]
+    if off + n > len(data):
+        return None
+    return data[off:off+n]
+
+def read_u8(roms, linear_addr):
+    b = read_at(roms, linear_addr, 1)
+    return b[0] if b else None
+
+def read_u16be(roms, linear_addr):
+    b = read_at(roms, linear_addr, 2)
+    return struct.unpack(">H", b)[0] if b else None
+
+def read_u24be(roms, linear_addr):
+    b = read_at(roms, linear_addr, 3)
+    return (b[0] << 16) | (b[1] << 8) | b[2] if b else None
+
+def find_catalog(u2):
+    """Find catalog offset in U2 (tries 0x3000, 0x4000, 0x6000)."""
+    for ofs in (0x3000, 0x4000, 0x6000):
+        size = u16be(u2, ofs) * 4096
+        chip_sel = u16be(u2, ofs + 2) >> 8
+        cksum = u16be(u2, ofs + 4)
+        if chip_sel == 0 and cksum == 0 and size == len(u2):
+            return ofs
+    return None
+
+def get_stream_header(roms, stream_addr):
+    """
+    Read the stream preamble to understand its type and configuration.
+    Returns dict with frame_count, header bytes, and packed-bit start address.
+    Most formats: 2-byte frame count + 16-byte header = 18 bytes preamble.
+    OS93a type1:  2-byte frame count + 1-byte header = 3 bytes preamble.
+    """
+    b = read_at(roms, stream_addr, 20)
+    if b is None:
+        return None
+    frame_count = (b[0] << 8) | b[1]
+    header = b[2:18]
+    return {
+        "frame_count": frame_count,
+        "header": header,
+        "raw20": b,
+    }
+
+def scan_tracks(roms, label):
+    u2 = roms[0]
+    cat_ofs = find_catalog(u2)
+    if cat_ofs is None:
+        print(f"  [{label}] ERROR: could not find catalog in U2")
+        return {}
+
+    track_index_addr = u24be(u2, cat_ofs + 0x40)
+    n_tracks         = u16be(u2, cat_ofs + 0x46)
+
+    print(f"\n{'='*70}")
+    print(f"  ROM set : {label}")
+    print(f"  Catalog : U2[${cat_ofs:05X}]")
+    print(f"  Track index : U2[${track_index_addr:05X}]  ({n_tracks} tracks)")
+    print(f"{'='*70}")
+
+    # Map: stream_addr -> list of (track_num, channel)
+    stream_refs = {}
+
+    for track_num in range(n_tracks + 1):
+        track_linear = u24be(u2, track_index_addr + track_num * 3)
+        if track_linear == 0 or track_linear == 0xFFFFFF:
+            continue
+
+        chip, off = make_rom_pointer(roms, track_linear)
+        if chip not in roms:
+            continue
+        data = roms[chip]
+        if off >= len(data):
+            continue
+
+        # Read track header: type byte + channel byte (at minimum)
+        track_type = data[off]
+        if track_type != 1:
+            # Only type 1 tracks have byte-code programs with Play opcodes
+            continue
+
+        channel = data[off + 1]
+        p = off + 2  # start of byte-code program
+
+        # Walk the byte-code program
+        for _ in range(4096):  # safety limit
+            if p + 2 > len(data):
+                break
+            delay = struct.unpack_from(">H", data, p)[0]
+            p += 2
+            if p >= len(data):
+                break
+            opcode = data[p]; p += 1
+
+            if opcode == 0x00:  # End
+                break
+            elif opcode == 0x01:  # Play stream
+                if p + 4 > len(data):
+                    break
+                ch       = data[p];     p += 1
+                s_addr   = (data[p] << 16) | (data[p+1] << 8) | data[p+2]; p += 3
+                repeat   = data[p];     p += 1
+                refs = stream_refs.setdefault(s_addr, [])
+                refs.append((track_num, ch))
+            elif opcode == 0x02:  p += 1      # Stop
+            elif opcode == 0x03:  p += 2      # Queue
+            elif opcode == 0x04:  p += 3      # varies
+            elif opcode == 0x05:  p += 1
+            elif opcode == 0x06:  p += 1
+            elif opcode == 0x07:  p += 2
+            elif opcode == 0x08:  p += 2
+            elif opcode == 0x09:  p += 2
+            elif opcode == 0x0A:  p += 2
+            elif opcode == 0x0B:  p += 4
+            elif opcode == 0x0C:  p += 3
+            else:
+                break  # unknown opcode, stop walking
+
+    return stream_refs
+
+def alignment_flags(addr):
+    """Return a string describing alignment violations."""
+    flags = []
+    if addr & 1:  flags.append("ODD(not 2-byte aligned!)")
+    elif addr & 3: flags.append("not 4-byte aligned")
+    elif addr & 7: flags.append("not 8-byte aligned")
+    else:          flags.append("8-byte aligned")
+    return ", ".join(flags)
+
+def report(label, roms, stream_refs, highlight_tracks=None):
+    print(f"\n--- {label}: stream alignment report ---")
+    print(f"{'Stream addr':>12}  {'Align':>6}  {'mod4':>4}  {'mod8':>4}  {'mod16':>5}  {'Tracks (sample)':40}")
+    print("-" * 90)
+
+    violations_4  = []
+    violations_8  = []
+    violations_16 = []
+
+    for addr in sorted(stream_refs):
+        tracks = stream_refs[addr]
+        track_str = ", ".join(f"${t:04X}/ch{c}" for t,c in tracks[:4])
+        if len(tracks) > 4:
+            track_str += f" (+{len(tracks)-4} more)"
+
+        mod2  = addr & 1
+        mod4  = addr & 3
+        mod8  = addr & 7
+        mod16 = addr & 15
+
+        flag = ""
+        if mod2:  flag = " *** ODD - DEFINITELY BROKEN ***"
+        elif mod4: flag = " * not 4-byte aligned"
+        elif mod8: flag = " * not 8-byte aligned"
+
+        # highlight track $01a6 et al.
+        hilite = ""
+        if highlight_tracks:
+            matching = [t for t,c in tracks if t in highlight_tracks]
+            if matching:
+                hilite = f"  <-- track(s) {[f'${x:04X}' for x in matching]}"
+
+        if mod4: violations_4.append(addr)
+        if mod8: violations_8.append(addr)
+        if mod16: violations_16.append(addr)
+
+        print(f"  ${addr:06X}    {'E' if not mod2 else 'O':>2}      {mod4:>1}     {mod8:>1}      {mod16:>2}   {track_str}{flag}{hilite}")
+
+    print(f"\n  Summary: {len(stream_refs)} streams total")
+    print(f"    Odd-aligned (mod2!=0)  : {sum(1 for a in stream_refs if a&1)}")
+    print(f"    Not 4-byte aligned     : {len(violations_4)}")
+    print(f"    Not 8-byte aligned     : {len(violations_8)}")
+    print(f"    Not 16-byte aligned    : {len(violations_16)}")
+
+
+def check_bank_boundary(addr, preamble_bytes=18):
+    """Return True if the preamble crosses a 4KB bank boundary."""
+    bank_end = (addr & ~0xFFF) + 0x1000
+    return (addr + preamble_bytes) > bank_end
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: check_alignment.py <rom_dir> [<rom_dir2>]")
+        print("  With one dir:  report alignment violations for that ROM set.")
+        print("  With two dirs: compare both sets side by side.")
+        sys.exit(1)
+
+    dirs = sys.argv[1:]
+    labels = [os.path.basename(os.path.abspath(d)) for d in dirs]
+
+    print("Loading ROMs...")
+    all_roms = []
+    for d, label in zip(dirs, labels):
+        roms = load_roms(d)
+        if not roms:
+            print(f"  ERROR: no ROM files found in {d}")
+            sys.exit(1)
+        chips = [f"U{k+2}" for k in sorted(roms.keys())]
+        print(f"  {label}: loaded {chips}")
+        all_roms.append(roms)
+
+    all_streams = []
+    for roms, label in zip(all_roms, labels):
+        streams = scan_tracks(roms, label)
+        all_streams.append(streams)
+        report(label, roms, streams)
+
+    # Bank-boundary violation report
+    for roms, streams, label in zip(all_roms, all_streams, labels):
+        violations = [(addr, tracks) for addr, tracks in streams.items()
+                      if check_bank_boundary(addr)]
+        print(f"\n--- {label}: 4KB bank-boundary violations (preamble crosses page) ---")
+        if not violations:
+            print("  None found.")
+        else:
+            for addr, tracks in sorted(violations):
+                bank_end = (addr & ~0xFFF) + 0x1000
+                overflow = (addr + 18) - bank_end
+                track_str = ", ".join(f"${t:04X}/ch{c}" for t, c in tracks[:4])
+                print(f"  ${addr:06X}  overflows by {overflow} bytes into next page  [{track_str}]")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The ADSP-2105 firmware accesses sound ROMs through a 4KB sliding bank window at DM($2000-$2FFF).  If a stream was placed such that its 18-byte preamble (frame count + header) crossed a 4KB boundary, reads would overflow into DM($3000+) — the memory-mapped bank-select register area — returning register values instead of ROM data.  This corrupted the stream header and caused the DCS CPU to crash deterministically when that sound was triggered.

The encoder only enforced 2-byte (even) alignment for stream placement, with no check for bank boundaries.  For example, a stream placed at page offset $FF8 within a 4KB bank has 10 bytes of its preamble overflowing into the register area.

Fix: add BankAlignFreePointer() to the ROMImage allocator.  Before each stream is placed, if the preamble would cross the current bank boundary, the free pointer is advanced to the start of the next bank.  The bank size is 0x1000 for original DCS boards and 0x800 for DCS-95.  The sizeNeeded estimate is increased by preambleBytes-1 to ensure the best-fit chip selection always reserves sufficient space.

Confirmed by testing six affected streams in a modified NBA Hangtime ROM set (nbatest10), all of which crashed before this fix.